### PR TITLE
Check index before lookup in vector

### DIFF
--- a/BlocksettleNetworkingLib/SelectedTransactionInputs.cpp
+++ b/BlocksettleNetworkingLib/SelectedTransactionInputs.cpp
@@ -248,6 +248,10 @@ const UTXO& SelectedTransactionInputs::GetTransaction(size_t i) const
 
 bool SelectedTransactionInputs::IsTransactionSelected(size_t i) const
 {
+   if (i < 0 || i >= selection_.size()) {
+      return false;
+   }
+
    return selection_[i];
 }
 

--- a/BlocksettleNetworkingLib/SelectedTransactionInputs.cpp
+++ b/BlocksettleNetworkingLib/SelectedTransactionInputs.cpp
@@ -248,7 +248,7 @@ const UTXO& SelectedTransactionInputs::GetTransaction(size_t i) const
 
 bool SelectedTransactionInputs::IsTransactionSelected(size_t i) const
 {
-   if (i < 0 || i >= selection_.size()) {
+   if (i >= selection_.size()) {
       return false;
    }
 


### PR DESCRIPTION
Issue: fix crash when trying to get index which is out of bound