### PR TITLE
Bst 2648

### DIFF
--- a/BlocksettleNetworkingLib/PasswordDialogData.cpp
+++ b/BlocksettleNetworkingLib/PasswordDialogData.cpp
@@ -257,6 +257,11 @@ void bs::sync::PasswordDialogData::setValue(const dialog::keys::Key &key, double
    setValueImpl(key, value);
 }
 
+void bs::sync::PasswordDialogData::setValue(const bs::sync::dialog::keys::Key &key, const QByteArray &value)
+{
+   setValueImpl(key, value);
+}
+
 void bs::sync::PasswordDialogData::remove(const bs::sync::dialog::keys::Key &key)
 {
    removeImpl(key.toQString());

--- a/BlocksettleNetworkingLib/PasswordDialogData.h
+++ b/BlocksettleNetworkingLib/PasswordDialogData.h
@@ -128,6 +128,7 @@ public:
    void setValue(const bs::sync::dialog::keys::Key &key, const std::string &value);
    void setValue(const bs::sync::dialog::keys::Key &key, int32_t value);
    void setValue(const bs::sync::dialog::keys::Key &key, double value);
+   void setValue(const bs::sync::dialog::keys::Key &key, const QByteArray &value);
 
    void remove(const bs::sync::dialog::keys::Key &key);
 

--- a/BlocksettleNetworkingLib/ProtobufHeadlessUtils.cpp
+++ b/BlocksettleNetworkingLib/ProtobufHeadlessUtils.cpp
@@ -28,6 +28,9 @@ headless::SignTxRequest bs::signer::coreTxRequestToPb(const bs::core::wallet::TX
    for (const auto &utxo : txSignReq.inputs) {
       request.add_inputs(utxo.serialize().toBinStr());
    }
+   for (const auto &inputIndex : txSignReq.inputIndices) {
+      request.add_input_indices(inputIndex);
+   }
 
    for (const auto &recip : txSignReq.recipients) {
       request.add_recipients(recip->getSerializedScript().toBinStr());
@@ -82,6 +85,8 @@ bs::core::wallet::TXSignRequest bs::signer::pbTxRequestToCore(const headless::Si
          txSignReq.inputs.push_back(utxo);
       }
    }
+   txSignReq.inputIndices.insert(txSignReq.inputIndices.end()
+      , request.input_indices().begin(), request.input_indices().end());
 
    uint64_t outputVal = 0;
    for (int i = 0; i < request.recipients_size(); i++) {

--- a/BlocksettleNetworkingLib/TradesUtils.cpp
+++ b/BlocksettleNetworkingLib/TradesUtils.cpp
@@ -213,13 +213,8 @@ void bs::tradeutils::createPayin(bs::tradeutils::PayinArgs args, bs::tradeutils:
 
                         auto recipients = std::vector<std::shared_ptr<ScriptRecipient>>(1, recipient);
                         try {
-                           std::vector<std::string> walletIds;
-                           for (const auto &wallet : args.inputXbtWallets) {
-                              walletIds.push_back(wallet->walletId());
-                           }
-
-                           std::string changeIndex = changeAddr.empty() ? "" : xbtWallet->getAddressIndex(changeAddr);
-                           result.signRequest = bs::sync::wallet::createTXRequest(walletIds, selectedInputs, recipients, changeAddr, changeIndex, fee, false);
+                           result.signRequest = bs::sync::wallet::createTXRequest(args.inputXbtWallets, selectedInputs
+                              , recipients, changeAddr, fee, false);
                            result.preimageData = preimages;
                            result.payinHash = result.signRequest.txId(resolver);
 

--- a/BlocksettleNetworkingLib/Wallets/SyncWallet.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWallet.h
@@ -47,6 +47,8 @@ namespace bs {
          virtual std::vector<std::string> securities() const = 0;
       };
 
+      class Wallet;
+
       namespace wallet {
 
          struct Comment
@@ -69,10 +71,16 @@ namespace bs {
          };
 
          // if there is change then changeAddr must be set
-         bs::core::wallet::TXSignRequest createTXRequest(const std::vector<std::string> &walletIds
+         bs::core::wallet::TXSignRequest createTXRequest(const std::vector<sync::Wallet*> &wallets
             , const std::vector<UTXO> &inputs
             , const std::vector<std::shared_ptr<ScriptRecipient>> &
-            , const bs::Address &changeAddr = {}, const std::string &changeIndex = {}
+            , const bs::Address &changeAddr = {}
+            , const uint64_t fee = 0, bool isRBF = false);
+
+         bs::core::wallet::TXSignRequest createTXRequest(const std::vector<std::shared_ptr<sync::Wallet>> &wallets
+            , const std::vector<UTXO> &inputs
+            , const std::vector<std::shared_ptr<ScriptRecipient>> &
+            , const bs::Address &changeAddr = {}
             , const uint64_t fee = 0, bool isRBF = false);
 
       }  // namepsace wallet

--- a/Blocksettle_proto/Communication/headless.proto
+++ b/Blocksettle_proto/Communication/headless.proto
@@ -102,6 +102,7 @@ message SignTxRequest
 {
    repeated string                  walletId = 1;
    repeated bytes                   inputs = 2;
+   repeated string                  input_indices = 12;
    repeated bytes                   recipients = 3;
    uint64                           fee = 4;
    bool                             RBF = 5;

--- a/WalletsLib/CoreHDWallet.cpp
+++ b/WalletsLib/CoreHDWallet.cpp
@@ -372,6 +372,15 @@ void hd::Wallet::createChatPrivKey()
    tx->insert(bwKey.getData(), chatNode_.getBase58());
 }
 
+void hd::Wallet::convertHardwareToWo()
+{
+   if (pwdMeta_.at(0).encType != bs::wallet::Hardware) {
+      throw std::logic_error("Only hardware wallet could be converted to WO");
+   }
+   pwdMeta_.at(0).encType = bs::wallet::Unencrypted;
+   writeToDB(true);
+}
+
 BIP32_Node hd::Wallet::getChatNode() const
 {
    if (!chatNode_.getPrivateKey().empty()) {

--- a/WalletsLib/CoreHDWallet.h
+++ b/WalletsLib/CoreHDWallet.h
@@ -102,6 +102,7 @@ namespace bs {
             void createStructure(unsigned lookup = UINT32_MAX);
             void createHwStructure(const bs::core::wallet::HwWalletInfo &walletInfo, unsigned lookup = UINT32_MAX);
             void createChatPrivKey();
+            void convertHardwareToWo();
 
             void shutdown();
             bool eraseFile();

--- a/WalletsLib/CoreWallet.h
+++ b/WalletsLib/CoreWallet.h
@@ -259,6 +259,7 @@ namespace bs {
          {
             std::vector<std::string>   walletIds;
             std::vector<UTXO>          inputs;
+            std::vector<std::string>   inputIndices;
             std::vector<std::shared_ptr<ScriptRecipient>>   recipients;
             std::map<BinaryData, BinaryData> supportingTxMap_;
             OutputSortOrder   outSortOrder{ OutputOrderType::PrevState

--- a/WalletsLib/CoreWalletsManager.cpp
+++ b/WalletsLib/CoreWalletsManager.cpp
@@ -103,6 +103,11 @@ WalletsManager::HDWalletPtr WalletsManager::loadWoWallet(NetworkType netType
          wallet->changeControlPassword({}, controlPassphrase);
       }
 
+      if (getHDWalletById(wallet->walletId())) {
+         logger_->error("Wallet {} already exists", wallet->walletId());
+         return nullptr;
+      }
+
       saveWallet(wallet);
       return wallet;
    } catch (const std::exception &e) {


### PR DESCRIPTION
We need UTXO input indices for offline sign with HW wallets.
This PR adds them to `headless.SignTxRequest` and `core::wallet::TXSignRequest`.
`convertHardwareToWo` is added for proper HW to WO wallet export.