### PR TITLE
Add change address index argument to create tx request function

### DIFF
--- a/BlocksettleNetworkingLib/TradesUtils.cpp
+++ b/BlocksettleNetworkingLib/TradesUtils.cpp
@@ -214,7 +214,7 @@ void bs::tradeutils::createPayin(bs::tradeutils::PayinArgs args, bs::tradeutils:
                         auto recipients = std::vector<std::shared_ptr<ScriptRecipient>>(1, recipient);
                         try {
                            result.signRequest = bs::sync::wallet::createTXRequest(args.inputXbtWallets, selectedInputs
-                              , recipients, changeAddr, fee, false);
+                              , recipients, changeAddr, {}, fee, false);
                            result.preimageData = preimages;
                            result.payinHash = result.signRequest.txId(resolver);
 

--- a/BlocksettleNetworkingLib/TransactionData.h
+++ b/BlocksettleNetworkingLib/TransactionData.h
@@ -127,7 +127,7 @@ public:
 
    // If there is change then changeAddr must be set
    bs::core::wallet::TXSignRequest createTXRequest(bool isRBF = false
-      , const bs::Address &changeAddr = {}) const;
+      , const bs::Address& changeAddr = {}, const std::string& changeIndex = {}) const;
 
    std::shared_ptr<SelectedTransactionInputs> getSelectedInputs() { return selectedInputs_; }
    TransactionSummary GetTransactionSummary() const;

--- a/BlocksettleNetworkingLib/Wallets/SyncWallet.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWallet.h
@@ -84,12 +84,14 @@ namespace bs {
             , const std::vector<UTXO> &inputs
             , const std::vector<std::shared_ptr<ScriptRecipient>> &
             , const bs::Address &changeAddr = {}
+            , const std::string &changeIndex = {}
             , const uint64_t fee = 0, bool isRBF = false);
 
          bs::core::wallet::TXSignRequest createTXRequest(const std::vector<std::shared_ptr<Wallet>> &wallets
             , const std::vector<UTXO> &inputs
             , const std::vector<std::shared_ptr<ScriptRecipient>> &
             , const bs::Address &changeAddr = {}
+            , const std::string &changeIndex = {}
             , const uint64_t fee = 0, bool isRBF = false);
 
       }  // namepsace wallet
@@ -188,7 +190,7 @@ namespace bs {
          virtual core::wallet::TXSignRequest createTXRequest(const std::vector<UTXO> &
             , const std::vector<std::shared_ptr<ScriptRecipient>> &
             , const uint64_t fee = 0, bool isRBF = false
-            , const bs::Address &changeAddress = {});
+            , const bs::Address &changeAddress = {}, const std::string &changeIndex = {});
          virtual core::wallet::TXSignRequest createPartialTXRequest(uint64_t spendVal
             , const std::vector<UTXO> &inputs, bs::Address changeAddress = {}
             , float feePerByte = 0


### PR DESCRIPTION
Issue: I want to have possibility to send change address without change wallet in request to signer

Particular case: when signing legacy address input from hw device, we include 1 legacy wallet in tx(since we do not allow to missing legacy with segwit) and change address could be only segwit(we do not have possibility to create change legacy address). So we want to address itself and address index will defined on terminal side.

Note: I did not find any useful case to send change wallet in purpose within the inputs dependent  wallets in tx request while creating simple tx 