### PR TITLE
BST-2678

### DIFF
--- a/BlocksettleNetworkingLib/Wallets/SyncWallet.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWallet.h
@@ -195,7 +195,7 @@ namespace bs {
             , const std::vector<std::shared_ptr<ScriptRecipient>> &recipients = {}
             , const bs::core::wallet::OutputSortOrder &outSortOrder = { bs::core::wallet::OutputOrderType::PrevState
                , bs::core::wallet::OutputOrderType::Recipients, bs::core::wallet::OutputOrderType::Change }
-            , const BinaryData prevPart = {}, bool feeCalcUsePrevPart = true);
+            , const BinaryData prevPart = {});
 
          virtual bool deleteRemotely() { return false; } //stub
          virtual void merge(const std::shared_ptr<Wallet>) = 0;

--- a/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
@@ -153,13 +153,14 @@ namespace bs {
          bool mergeableEntries(const bs::TXEntry &, const bs::TXEntry &) const;
          std::vector<bs::TXEntry> mergeEntries(const std::vector<bs::TXEntry> &) const;
 
-         core::wallet::TXSignRequest createPartialTXRequest(uint64_t spendVal
+         static core::wallet::TXSignRequest createPartialTXRequest(uint64_t spendVal
             , const std::map<UTXO, std::string> &inputs, bs::Address changeAddress = {}
-            , float feePerByte = 0
+            , float feePerByte = 0, uint32_t topHeight = 0
             , const std::vector<std::shared_ptr<ScriptRecipient>> &recipients = {}
             , const bs::core::wallet::OutputSortOrder &outSortOrder = { bs::core::wallet::OutputOrderType::PrevState
                , bs::core::wallet::OutputOrderType::Recipients, bs::core::wallet::OutputOrderType::Change }
-         , const BinaryData prevPart = {}, bool feeCalcUsePrevPart = true, bool useAllInputs = false);
+            , const BinaryData prevPart = {}, bool useAllInputs = false
+            , const std::shared_ptr<spdlog::logger> &logger = nullptr);
 
          std::shared_ptr<ColoredCoinTrackerClient> tracker(const std::string &cc) const;
 


### PR DESCRIPTION
http://185.213.153.35:8081/browse/BST-2678
CC UTXO selection fixes (and remove duplicated code)
The problem was that we were selecting UTXOs without covering fee for CC part and this check sometimes failed:
```
   if (inputAmount < (spendVal + fee)) {
      throw std::overflow_error("Not enough inputs (" + std::to_string(inputAmount)
         + ") to spend " + std::to_string(spendVal + fee));
   }
```
No change in unit tests passing