### PR TITLE
Move hw wallet sign functionality inside hd root wallet

### DIFF
--- a/BlocksettleNetworkingLib/HeadlessContainerListener.cpp
+++ b/BlocksettleNetworkingLib/HeadlessContainerListener.cpp
@@ -431,64 +431,10 @@ bool HeadlessContainerListener::onSignTxRequest(const std::string &clientId, con
       if (rootWallet->isWatchingOnly()) {
          // when signing tx for watching-only wallet we receiving signed tx
          // from signer ui instead of password
-         bool isLedgerHw = false;
          if (rootWallet->isHardwareWallet()) {
-            bs::wallet::HardwareEncKey hwEncKey(rootWallet->encryptionKeys()[0]);
-            isLedgerHw = hwEncKey.deviceType() == bs::wallet::HardwareEncKey::WalletType::Ledger;
-         }
-
-         if (isLedgerHw) {
-            // For ledger hw data is not prepared straight away
-            Blocksettle::Communication::headless::InputSigs sigs;
-            if (!sigs.ParseFromString(pass.toBinStr())) {
-               logger_->error("[{}] Cannot parse sig sign response"
-                  , __func__);
-               SignTXResponse(clientId, id, reqType, ErrorCode::WalletNotFound);
-               return;
-            }
-
-            bs::core::InputSigs inputSigs;
-            for (size_t i = 0; i < sigs.inputsig_size(); ++i) {
-               auto sig = sigs.inputsig(i);
-               inputSigs[sig.index()] = BinaryData::fromString(sig.data());
-            }
-
-            if (wallets.size() == 1) {
-               auto signedTx = wallets[0]->signTXRequestWithWitness(txSignReq, inputSigs);
-               SignTXResponse(clientId, id, reqType, ErrorCode::NoError, signedTx);
-            }
-            else {
-               bs::core::wallet::TXMultiSignRequest multiReq;
-               multiReq.recipients = txSignReq.recipients;
-               if (txSignReq.change.value) {
-                  multiReq.recipients.push_back(txSignReq.change.address.getRecipient(bs::XBTAmount{ txSignReq.change.value }));
-               }
-               if (!txSignReq.prevStates.empty()) {
-                  multiReq.prevState = txSignReq.prevStates.front();
-               }
-               multiReq.RBF = txSignReq.RBF;
-
-               bs::core::WalletMap wallets;
-               for (const auto &input : txSignReq.inputs) {
-                  const auto addr = bs::Address::fromUTXO(input);
-                  const auto wallet = walletsMgr_->getWalletByAddress(addr);
-                  if (!wallet) {
-                     logger_->error("[{}] failed to find wallet for input address {}"
-                        , __func__, addr.display());
-                     SignTXResponse(clientId, id, reqType, ErrorCode::WalletNotFound);
-                     return;
-                  }
-                  multiReq.addInput(input, wallet->walletId());
-                  wallets[wallet->walletId()] = wallet;
-               }
-
-               BinaryData tx;
-               {
-                  const bs::core::WalletPasswordScoped passLock(rootWallet, pass);
-                  tx = bs::core::SignMultiInputTXWithWitness(multiReq, wallets, inputSigs);
-               }
-               SignTXResponse(clientId, id, reqType, ErrorCode::NoError, tx);
-            }
+            bs::core::WalletPasswordScoped lock(rootWallet, pass);
+            auto signedTx = rootWallet->signTXRequestWithWallet(txSignReq);
+            SignTXResponse(clientId, id, reqType, ErrorCode::NoError, signedTx);
          }
          else {
             SignTXResponse(clientId, id, reqType, ErrorCode::NoError, pass);

--- a/WalletsLib/CoreHDWallet.cpp
+++ b/WalletsLib/CoreHDWallet.cpp
@@ -358,7 +358,7 @@ BinaryData bs::core::hd::Wallet::signTXRequestWithWallet(const bs::core::wallet:
       bs::wallet::HardwareEncKey hwEncKey(encryptionKeys()[0]);
 
       if (lbdPwdPrompts_.empty()) {
-         throw std::logic_error(fmt::format("Incorrect hw wallet data {}", request.walletIds.front()));
+         throw std::logic_error("password lambda not set");
       }
 
       std::set<BinaryData> binaryData;

--- a/WalletsLib/CoreHDWallet.cpp
+++ b/WalletsLib/CoreHDWallet.cpp
@@ -357,6 +357,10 @@ BinaryData bs::core::hd::Wallet::signTXRequestWithWallet(const bs::core::wallet:
    if (isHardwareWallet()) {
       bs::wallet::HardwareEncKey hwEncKey(encryptionKeys()[0]);
 
+      if (lbdPwdPrompts_.empty()) {
+         throw std::logic_error(fmt::format("Incorrect hw wallet data {}", request.walletIds.front()));
+      }
+
       std::set<BinaryData> binaryData;
       auto signedDeviceSigs = lbdPwdPrompts_.back()(binaryData);
 

--- a/WalletsLib/CoreHDWallet.h
+++ b/WalletsLib/CoreHDWallet.h
@@ -137,6 +137,8 @@ namespace bs {
             BinaryData signSettlementTXRequest(const wallet::TXSignRequest &
                , const wallet::SettlementData &);
 
+            BinaryData signTXRequestWithWallet(const bs::core::wallet::TXSignRequest &request);
+
          protected:
             std::string    name_, desc_;
             NetworkType    netType_ = NetworkType::Invalid;


### PR DESCRIPTION
Issue: we want to hind hw sign functionality in hw root wallet to make possible to reuse it in different place
