### PR TITLE
Updated Qt to 5.12.8

### DIFF
--- a/build_scripts/qt_settings.py
+++ b/build_scripts/qt_settings.py
@@ -14,7 +14,7 @@ class QtSettings(Configurator):
         self.jom = JomSettings(settings)
         self.openssl = OpenSslSettings(settings)
         self._release = '5.12'
-        self._version = self._release + '.5'
+        self._version = self._release + '.8'
         self._package_name = 'qt-everywhere-src-' + self._version
         self._script_revision = '8'
 


### PR DESCRIPTION
Mainly a polish release of Qt (e.g. removed useless output in Linux console).
Tested the build on Ubuntu 20.04