### PR TITLE
Fix bip39 and add electrum seeds verification logic

### DIFF
--- a/CommonLib/Bip39.cpp
+++ b/CommonLib/Bip39.cpp
@@ -53,8 +53,7 @@ namespace {
 
       size_t keyLength = key.getSize();
       BinaryWriter packer(keyLength);
-      for (size_t count = 1; keyLength > 0; count++)
-      {
+      for (size_t count = 1; keyLength > 0; count++) {
          asalt.append((count >> 24) & 0xff);
          asalt.append((count >> 16) & 0xff);
          asalt.append((count >> 8) & 0xff);
@@ -63,13 +62,13 @@ namespace {
             asalt.getPtr(), asalt.getSize(), digest1.getPtr());
          buffer = digest1;
 
-         for (size_t iteration = 1; iteration < iterations; iteration++)
-         {
+         for (size_t iteration = 1; iteration < iterations; iteration++) {
             BtcUtils::getHMAC512(passphrase.getPtr(), passphrase.getSize(), digest1.getPtr(), digest1.getSize(),
                digest2.getPtr());
             digest1 = digest2;
-            for (size_t index = 0; index < buffer.getSize(); index++)
+            for (size_t index = 0; index < buffer.getSize(); index++) {
                buffer[index] ^= digest1[index];
+            }
          }
 
          const size_t length = (keyLength < buffer.getSize() ? keyLength : buffer.getSize());
@@ -83,8 +82,9 @@ namespace {
 
    std::vector<std::string> createBip39Mnemonic(const BinaryData& entropy, const std::vector<std::string>& dictionary)
    {
-      if ((entropy.getSize() % kMnemonicSeedMult) != 0)
+      if ((entropy.getSize() % kMnemonicSeedMult) != 0) {
          return {};
+      }
 
       const size_t entropyBits = (entropy.getSize() * kByteBits);
       const size_t checkBits = (entropyBits / kEntropyBitDevisor);
@@ -100,18 +100,17 @@ namespace {
       size_t bit = 0;
       std::vector<std::string> words;
 
-      for (size_t word = 0; word < wordCount; word++)
-      {
+      for (size_t word = 0; word < wordCount; word++) {
          size_t position = 0;
-         for (size_t loop = 0; loop < kBitsPerMnemonicWord; loop++)
-         {
+         for (size_t loop = 0; loop < kBitsPerMnemonicWord; loop++) {
             bit = (word * kBitsPerMnemonicWord + loop);
             position <<= 1;
 
             const auto byte = bit / kByteBits;
 
-            if ((chunk[byte] & bip39_shift(bit)) > 0)
+            if ((chunk[byte] & bip39_shift(bit)) > 0) {
                position++;
+            }
          }
 
          assert(position < dictionary.size());
@@ -137,8 +136,7 @@ namespace {
 
       BinaryData chunk((totalBits + kByteBits - 1) / kByteBits);
       size_t globalBit = 0;
-      for (const auto& word : words)
-      {
+      for (const auto& word : words) {
          auto wordIter = std::find(dictionary.cbegin(), dictionary.cend(), word);
          if (wordIter == dictionary.cend()) {
             return false;
@@ -147,10 +145,8 @@ namespace {
          const auto position = std::distance(dictionary.cbegin(), wordIter);
          assert(position != -1);
 
-         for (size_t bit = 0; bit < kBitsPerMnemonicWord; bit++, globalBit++)
-         {
-            if (position & (1 << (kBitsPerMnemonicWord - bit - 1)))
-            {
+         for (size_t bit = 0; bit < kBitsPerMnemonicWord; bit++, globalBit++) {
+            if (position & (1 << (kBitsPerMnemonicWord - bit - 1))) {
                const auto byte = globalBit / kByteBits;
                chunk[byte] |= bip39_shift(globalBit);
             }

--- a/CommonLib/Bip39.cpp
+++ b/CommonLib/Bip39.cpp
@@ -17,148 +17,246 @@
 #include "BtcUtils.h"
 
 namespace {
-   constexpr size_t mnemonicWordMult = 3;
-   constexpr size_t mnemonicSeedMult = 4;
-   constexpr size_t bitsPerMnemonicWord = 11;
-   constexpr size_t entropyBitDevisor = 32;
-   constexpr size_t hmacIteration = 2048;
-   constexpr size_t dictionarySize = 2048;
-   constexpr uint8_t byteBits = 8;
-   const std::string saltPrefix = "mnemonic";
+   constexpr size_t kMnemonicWordMult = 3;
+   constexpr size_t kMnemonicSeedMult = 4;
+   constexpr size_t kBitsPerMnemonicWord = 11;
+   constexpr size_t kEntropyBitDevisor = 32;
+   constexpr size_t kHmacIteration = 2048;
+   constexpr size_t kDictionarySize = 2048;
+   constexpr uint8_t kByteBits = 8;
+   constexpr size_t kElectrumSentenceLength = 12;
+   const std::string kBip39SaltPrefix = "mnemonic";
+   const std::string kElectrumSaltPrefix = "electrum";
+   const std::string kElectrumSeedPrefix = "Seed version";
+   
+   // https://electrum.readthedocs.io/en/latest/seedphrase.html?highlight=bip39
+   const std::set<std::string> kElectrumPrefixes = {
+      "01",  // Standard
+      "100", // Segwit
+      // We do not support two-factor authenticated wallets
+      // "101", // Two-factor authenticated wallets standard
+      // "102"  // Two-factor authenticated wallets segwit
+   };
 
    inline uint8_t bip39_shift(size_t bit)
    {
-      return (1 << (byteBits - (bit % byteBits) - 1));
+      return (1 << (kByteBits - (bit % kByteBits) - 1));
    }
-}
 
-std::vector<std::string> create_mnemonic(const BinaryData& entropy, const std::vector<std::string>& dictionary)
-{
-   if ((entropy.getSize() % mnemonicSeedMult) != 0)
-      return {};
-
-   const size_t entropyBits = (entropy.getSize() * byteBits);
-   const size_t checkBits = (entropyBits / entropyBitDevisor);
-   const size_t totalBits = (entropyBits + checkBits);
-   const size_t wordCount = (totalBits / bitsPerMnemonicWord);
-
-   assert((totalBits % bitsPerMnemonicWord) == 0);
-   assert((wordCount % mnemonicWordMult) == 0);
-
-   BinaryData chunk = entropy;
-   chunk.append(BtcUtils::getSha256(entropy));
-
-   size_t bit = 0;
-   std::vector<std::string> words;
-
-   for (size_t word = 0; word < wordCount; word++)
+   bool pkcs5_pbkdf2(const SecureBinaryData& passphrase, const BinaryData& salt,
+      SecureBinaryData& key, size_t iterations)
    {
-      size_t position = 0;
-      for (size_t loop = 0; loop < bitsPerMnemonicWord; loop++)
+      BinaryData asalt = salt;
+      SecureBinaryData buffer(64U);
+      SecureBinaryData digest1(64U);
+      SecureBinaryData digest2(64U);
+
+      size_t keyLength = key.getSize();
+      BinaryWriter packer(keyLength);
+      for (size_t count = 1; keyLength > 0; count++)
       {
-         bit = (word * bitsPerMnemonicWord + loop);
-         position <<= 1;
+         asalt.append((count >> 24) & 0xff);
+         asalt.append((count >> 16) & 0xff);
+         asalt.append((count >> 8) & 0xff);
+         asalt.append(count & 0xff);
+         BtcUtils::getHMAC512(passphrase.getPtr(), passphrase.getSize(),
+            asalt.getPtr(), asalt.getSize(), digest1.getPtr());
+         buffer = digest1;
 
-         const auto byte = bit / byteBits;
+         for (size_t iteration = 1; iteration < iterations; iteration++)
+         {
+            BtcUtils::getHMAC512(passphrase.getPtr(), passphrase.getSize(), digest1.getPtr(), digest1.getSize(),
+               digest2.getPtr());
+            digest1 = digest2;
+            for (size_t index = 0; index < buffer.getSize(); index++)
+               buffer[index] ^= digest1[index];
+         }
 
-         if ((chunk[byte] & bip39_shift(bit)) > 0)
-            position++;
+         const size_t length = (keyLength < buffer.getSize() ? keyLength : buffer.getSize());
+         packer.put_BinaryData(buffer.getSliceRef(0, length));
+         keyLength -= length;
+      };
+      key = packer.getData();
+
+      return true;
+   }
+
+   std::vector<std::string> createBip39Mnemonic(const BinaryData& entropy, const std::vector<std::string>& dictionary)
+   {
+      if ((entropy.getSize() % kMnemonicSeedMult) != 0)
+         return {};
+
+      const size_t entropyBits = (entropy.getSize() * kByteBits);
+      const size_t checkBits = (entropyBits / kEntropyBitDevisor);
+      const size_t totalBits = (entropyBits + checkBits);
+      const size_t wordCount = (totalBits / kBitsPerMnemonicWord);
+
+      assert((totalBits % kBitsPerMnemonicWord) == 0);
+      assert((wordCount % kMnemonicWordMult) == 0);
+
+      BinaryData chunk = entropy;
+      chunk.append(BtcUtils::getSha256(entropy));
+
+      size_t bit = 0;
+      std::vector<std::string> words;
+
+      for (size_t word = 0; word < wordCount; word++)
+      {
+         size_t position = 0;
+         for (size_t loop = 0; loop < kBitsPerMnemonicWord; loop++)
+         {
+            bit = (word * kBitsPerMnemonicWord + loop);
+            position <<= 1;
+
+            const auto byte = bit / kByteBits;
+
+            if ((chunk[byte] & bip39_shift(bit)) > 0)
+               position++;
+         }
+
+         assert(position < dictionary.size());
+         words.push_back(dictionary[position]);
       }
 
-      assert(position < dictionary.size());
-      words.push_back(dictionary[position]);
+      assert(words.size() == ((bit + 1) / kBitsPerMnemonicWord));
+      return words;
    }
 
-   assert(words.size() == ((bit + 1) / bitsPerMnemonicWord));
-   return words;
-}
-
-bool validate_mnemonic(const std::vector<std::string> &words, const std::vector<std::string>& dictionary)
-{
-   const auto wordsCount = words.size();
-   if ((wordsCount % mnemonicWordMult) != 0) {
-      return false;
-   }
-
-   const size_t totalBits = bitsPerMnemonicWord * wordsCount;
-   const size_t checkBits = totalBits / (entropyBitDevisor + 1);
-   const size_t entropyBits = totalBits - checkBits;
-
-   assert(entropyBits % byteBits == 0);
-
-   BinaryData chunk((totalBits + byteBits - 1) / byteBits);
-   size_t globalBit = 0;
-   for (const auto& word : words)
+   bool validateBip39Mnemonic(const std::vector<std::string> &words, const std::vector<std::string>& dictionary)
    {
-      auto wordIter = std::find(dictionary.cbegin(), dictionary.cend(), word);
-      if (wordIter == dictionary.cend()) {
+      const auto wordsCount = words.size();
+      if ((wordsCount % kMnemonicWordMult) != 0) {
          return false;
       }
 
-      const auto position = std::distance(dictionary.cbegin(), wordIter);
-      assert(position != -1);
+      const size_t totalBits = kBitsPerMnemonicWord * wordsCount;
+      const size_t checkBits = totalBits / (kEntropyBitDevisor + 1);
+      const size_t entropyBits = totalBits - checkBits;
 
-      for (size_t bit = 0; bit < bitsPerMnemonicWord; bit++, globalBit++)
+      assert(entropyBits % kByteBits == 0);
+
+      BinaryData chunk((totalBits + kByteBits - 1) / kByteBits);
+      size_t globalBit = 0;
+      for (const auto& word : words)
       {
-         if (position & (1 << (bitsPerMnemonicWord - bit - 1)))
-         {
-            const auto byte = globalBit / byteBits;
-            chunk[byte] |= bip39_shift(globalBit);
+         auto wordIter = std::find(dictionary.cbegin(), dictionary.cend(), word);
+         if (wordIter == dictionary.cend()) {
+            return false;
          }
+
+         const auto position = std::distance(dictionary.cbegin(), wordIter);
+         assert(position != -1);
+
+         for (size_t bit = 0; bit < kBitsPerMnemonicWord; bit++, globalBit++)
+         {
+            if (position & (1 << (kBitsPerMnemonicWord - bit - 1)))
+            {
+               const auto byte = globalBit / kByteBits;
+               chunk[byte] |= bip39_shift(globalBit);
+            }
+         }
+      }
+
+      chunk.resize(entropyBits / kByteBits);
+      const auto mnemonic = createBip39Mnemonic(chunk, dictionary);
+      return std::equal(mnemonic.begin(), mnemonic.end(), words.begin());
+   }
+
+   std::vector<std::string> splitMnemonicWords(const std::string& sentence) {
+      std::vector<std::string> words;
+      std::istringstream iss(sentence);
+      std::copy(std::istream_iterator<std::string>(iss),
+         std::istream_iterator<std::string>(),
+         std::back_inserter(words));
+
+      return words;
+   }
+
+   std::string normalize(const std::vector<std::string>& words) {
+      std::ostringstream oss;
+      std::copy(words.begin(), words.end() - 1,
+         std::ostream_iterator<std::string>(oss, " "));
+      oss << words.back();
+
+      return oss.str();
+   }
+
+   std::string normalize(const std::string& sentence) {
+      std::vector<std::string> words = splitMnemonicWords(sentence);
+      return normalize(words);
+   }
+
+   bool isElectrumKnownPrefix(const std::string& prefix) {
+      return kElectrumPrefixes.count(prefix) > 0;
+   }
+}
+
+bool validateBip39Mnemonic(const std::string& sentence,
+   const std::vector<std::vector<std::string>>& dictionaries)
+{
+   std::vector<std::string> words = splitMnemonicWords(sentence);
+   for (auto const &dictionary : dictionaries) {
+      if (validateBip39Mnemonic(words, dictionary)) {
+         return true;
+         break;
       }
    }
 
-   chunk.resize(entropyBits / byteBits);
-   const auto mnemonic = create_mnemonic(chunk, dictionary);
-   return std::equal(mnemonic.begin(), mnemonic.end(), words.begin());
+   return false;
 }
 
-bool pkcs5_pbkdf2(const SecureBinaryData& passphrase, const BinaryData& salt,
-   SecureBinaryData& key, size_t iterations)
+bool validateElectrumMnemonic(const std::string& sentence)
 {
-   BinaryData asalt = salt;
-   SecureBinaryData buffer(64U);
-   SecureBinaryData digest1(64U);
-   SecureBinaryData digest2(64U);
+   const auto words = splitMnemonicWords(sentence);
+   if (words.size() != kElectrumSentenceLength) {
+      return false;
+   }
 
-   size_t keyLength = key.getSize();
-   BinaryWriter packer(keyLength);
-   for (size_t count = 1; keyLength > 0; count++)
-   {
-      asalt.append((count >> 24) & 0xff);
-      asalt.append((count >> 16) & 0xff);
-      asalt.append((count >> 8) & 0xff);
-      asalt.append(count & 0xff);
-      BtcUtils::getHMAC512(passphrase.getPtr(), passphrase.getSize(),
-         asalt.getPtr(), asalt.getSize(), digest1.getPtr());
-      buffer = digest1;
+   std::string normalized = normalize(words);
+   const auto hmac = BtcUtils::getHMAC512(SecureBinaryData::fromString(kElectrumSeedPrefix),
+      normalized);
+   const size_t length = (hmac[0] >> 4) + 2;
+   auto prefix = hmac.getSliceRef(0, (length / 2) + 1).toHexStr();
+   if (length % 2 != 0) {
+      prefix.pop_back();
+   }
 
-      for (size_t iteration = 1; iteration < iterations; iteration++)
-      {
-         BtcUtils::getHMAC512(passphrase.getPtr(), passphrase.getSize(), digest1.getPtr(), digest1.getSize(),
-            digest2.getPtr());
-         digest1 = digest2;
-         for (size_t index = 0; index < buffer.getSize(); index++)
-            buffer[index] ^= digest1[index];
-      }
+   return isElectrumKnownPrefix(prefix);
+}
 
-      const size_t length = (keyLength < buffer.getSize() ? keyLength : buffer.getSize());
-      packer.put_BinaryData(buffer.getSliceRef(0, length));
-      keyLength -= length;
-   };
-   key = packer.getData();
+bool validateMnemonic(const std::string& sentence,
+   const std::vector<std::vector<std::string>>& dictionaries)
+{
+   // #ElectrumSeedsSupport : verifying seeds against electrum logic is skipping for now
+   // Since possible situation that mnemonic sentence could be parsed
+   // as bip39 seeds and as electrum seed version in the same time
+   // we will avoid to detect wallet in this case.
+   // So according to this logic, sentence is valid only if
+   // it parsed correctly by one method only
+   //return validateBip39Mnemonic(sentence, dictionaries) 
+   //   != validateElectrumMnemonic(sentence);
 
-   return true;
+   // For now we do only bip39 validation
+   return validateBip39Mnemonic(sentence, dictionaries);
 }
 
 SecureBinaryData bip39GetSeedFromMnemonic(const std::string& sentence)
 {
-   const std::string salt(saltPrefix);
+   std::string salt;
+
+   // #ElectrumSeedsSupport : salt support skipped for now
+   //if (validateElectrumMnemonic(sentence)) {
+   //   salt = kElectrumSaltPrefix;
+   //}
+   //else {
+   //   salt = kBip39SaltPrefix;
+   //}
+   salt = kBip39SaltPrefix;
 
    SecureBinaryData result(64);
-   const auto success = pkcs5_pbkdf2(SecureBinaryData::fromString(sentence),
+   const auto success = pkcs5_pbkdf2(SecureBinaryData::fromString(normalize(sentence)),
       BinaryData::fromString(salt),
-      result, hmacIteration);
+      result, kHmacIteration);
 
    return success ? result : SecureBinaryData();
 }

--- a/CommonLib/Bip39.cpp
+++ b/CommonLib/Bip39.cpp
@@ -194,7 +194,6 @@ bool validateBip39Mnemonic(const std::string& sentence,
    for (auto const &dictionary : dictionaries) {
       if (validateBip39Mnemonic(words, dictionary)) {
          return true;
-         break;
       }
    }
 

--- a/CommonLib/Bip39.h
+++ b/CommonLib/Bip39.h
@@ -13,24 +13,19 @@
 
 #include "BinaryData.h"
 
-// Create mnemonic sentence from entropy and dictionary
-std::vector<std::string> create_mnemonic(const BinaryData& entropy,
-   const std::vector<std::string>& dictionary);
-
-// validate mnemonic words against particular dictionary
-bool validate_mnemonic(const std::vector<std::string> &words,
-   const std::vector<std::string>& dictionary);
-
-// validate mnemonic words against list of dictionaries
-bool validate_mnemonic(const std::vector<std::string> &words,
+// validate bip39 mnemonic words against list of dictionaries
+bool validateBip39Mnemonic(const std::string& sentence,
    const std::vector<std::vector<std::string>>& dictionaries);
 
-// pbkdf2 algorithm to get bip39 root seed without passphrase
-bool pkcs5_pbkdf2(const uint8_t* passphrase, size_t passphrase_length,
-   const uint8_t* salt, size_t salt_length, uint8_t* key, size_t key_length,
-   size_t iterations);
+// validate electrum mnemonic words against list of dictionaries
+bool validateElectrumMnemonic(const std::string& sentence);
 
-// return bip39 root seed which could be converted to bip32 root key
+// check for bip39 & electrum mnemonic compatibility
+bool validateMnemonic(const std::string& sentence,
+   const std::vector<std::vector<std::string>>& dictionaries);
+
+// return bip32 root seed which could be converted to bip32 root key
+// this is the same for bip39 protocol and for electrum seed generation system
 SecureBinaryData bip39GetSeedFromMnemonic(const std::string& sentence);
 
 #endif // __BS_BIP39_H_

--- a/WalletsLib/CoreWallet.cpp
+++ b/WalletsLib/CoreWallet.cpp
@@ -767,26 +767,12 @@ wallet::Seed wallet::Seed::fromBip39(const std::string& sentence,
       return seed;
    }
 
-   std::vector<std::string> words;
-   std::istringstream iss(sentence);
-   std::copy(std::istream_iterator<std::string>(iss),
-      std::istream_iterator<std::string>(),
-      std::back_inserter(words));
-
-   bool success = false;
-   for (const auto& dict : dictionaries) {
-      if (validate_mnemonic(words, dict)) {
-         success = true;
-         break;
-      }
-   }
-
-   if (!success) {
+   if (!validateMnemonic(sentence, dictionaries)) {
       return seed;
    }
 
-   SecureBinaryData bip39Seed = bip39GetSeedFromMnemonic(sentence);
-   seed = bs::core::wallet::Seed(bip39Seed, netType);
+   SecureBinaryData bip32Seed = bip39GetSeedFromMnemonic(sentence);
+   seed = bs::core::wallet::Seed(bip32Seed, netType);
 
    return seed;
 }


### PR DESCRIPTION
Issues:
1. Fix whitespaces in bip39 seeds detection
2. Add support for electrum wallet seeds verifying ( note : task with adding wallet from electrum seed is not done on this review since electrum derivation schema is different from one we using, so for now I only left seeds detection logic which is not using atm)