### PR TITLE
Add unknown state for sync::Wallet::isTxValid

### DIFF
--- a/BlocksettleNetworkingLib/ColoredCoinLogic.cpp
+++ b/BlocksettleNetworkingLib/ColoredCoinLogic.cpp
@@ -171,6 +171,11 @@ void ColoredCoinTracker::setZcSnapshotUpdatedCb(ColoredCoinTrackerInterface::Sna
    zcSnapshotUpdatedCb_ = std::move(cb);
 }
 
+void ColoredCoinTracker::setReadyCb(ColoredCoinTrackerInterface::SnapshotUpdatedCb cb)
+{
+   readyCb_ = std::move(cb);
+}
+
 ////
 const std::shared_ptr<BinaryData> ColoredCoinTracker::getScrAddrPtr(
    const std::map<BinaryData, OpPtrSet>& addrMap
@@ -1533,8 +1538,16 @@ bool ColoredCoinTracker::goOnline()
 
    //flag ready
    ready_.store(true, std::memory_order_relaxed);
+   if (readyCb_) {
+      readyCb_();
+   }
 
    return true;
+}
+
+bool ColoredCoinTracker::ready() const
+{
+   return ready_.load();
 }
 
 ////
@@ -1650,6 +1663,11 @@ void ColoredCoinTrackerClient::parseCcCandidateTx(const Tx &tx
    auto ssPtr = ccSnapshots_->snapshot();
    auto zcPtr = ccSnapshots_->zcSnapshot();
    ccSnapshots_->parseCcCandidateTx(ssPtr, zcPtr, tx, cb);
+}
+
+bool ColoredCoinTrackerClient::ready() const
+{
+   return ccSnapshots_->ready();
 }
 
 ////

--- a/BlocksettleNetworkingLib/ColoredCoinLogic.h
+++ b/BlocksettleNetworkingLib/ColoredCoinLogic.h
@@ -251,11 +251,14 @@ public:
    using SnapshotUpdatedCb = std::function<void()>;
    virtual void setSnapshotUpdatedCb(SnapshotUpdatedCb cb) = 0;
    virtual void setZcSnapshotUpdatedCb(SnapshotUpdatedCb cb) = 0;
+   virtual void setReadyCb(SnapshotUpdatedCb cb) = 0;
 
    virtual void parseCcCandidateTx(
       const std::shared_ptr<ColoredCoinSnapshot>&,
       const std::shared_ptr<ColoredCoinZCSnapshot>&,
       const Tx&, const CcTxCandidateCb &) const = 0;
+
+   virtual bool ready() const = 0;
 };
 
 ////
@@ -289,6 +292,7 @@ private:
 
    SnapshotUpdatedCb snapshotUpdatedCb_;
    SnapshotUpdatedCb zcSnapshotUpdatedCb_;
+   SnapshotUpdatedCb readyCb_;
 
 protected:
    std::shared_ptr<AsyncClient::BtcWallet> walletObj_;
@@ -389,6 +393,7 @@ public:
 
    void setSnapshotUpdatedCb(SnapshotUpdatedCb cb) override;
    void setZcSnapshotUpdatedCb(SnapshotUpdatedCb cb) override;
+   void setReadyCb(SnapshotUpdatedCb cb) override;
 
    ////
    static uint64_t getCcOutputValue(
@@ -423,6 +428,8 @@ public:
 
    ////
    bool goOnline(void) override;
+
+   bool ready() const override;
 };
 
 class ColoredCoinTrackerClientIface
@@ -497,6 +504,8 @@ public:
       , bool withZc) const override;
 
    void parseCcCandidateTx(const Tx &, const CcTxCandidateCb &) const override;
+
+   bool ready() const;
 };
 
 class CCTrackerClientFactory

--- a/BlocksettleNetworkingLib/Wallets/SyncHDLeaf.cpp
+++ b/BlocksettleNetworkingLib/Wallets/SyncHDLeaf.cpp
@@ -1171,12 +1171,19 @@ std::vector<uint64_t> hd::CCLeaf::getAddrBalance(const bs::Address &addr) const
       , tracker_->getConfirmedCcValueForAddresses({ addr.id() }) / lotSize_ };
 }
 
-bool hd::CCLeaf::isTxValid(const BinaryData &txHash) const
+TxValidity hd::CCLeaf::isTxValid(const BinaryData &txHash) const
 {
    if (!tracker_) {
-      return true;
+      return TxValidity::Unknown;
    }
-   return tracker_->isTxHashValidHistory(txHash);
+   if (tracker_->isTxHashValidHistory(txHash)) {
+      return TxValidity::Valid;
+   }
+   // Can't say for sure until tracker is ready, mark as unknown for now
+   if (!tracker_->ready()) {
+      return TxValidity::Unknown;
+   }
+   return TxValidity::Invalid;
 }
 
 BTCNumericTypes::balance_type hd::CCLeaf::getTxBalance(int64_t val) const

--- a/BlocksettleNetworkingLib/Wallets/SyncHDLeaf.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncHDLeaf.h
@@ -244,7 +244,7 @@ namespace bs {
             BTCNumericTypes::balance_type getTxBalance(int64_t) const override;
             QString displayTxValue(int64_t val) const override;
             QString displaySymbol() const override;
-            bool isTxValid(const BinaryData &) const override;
+            TxValidity isTxValid(const BinaryData &) const override;
 
             void setArmory(const std::shared_ptr<ArmoryConnection> &) override;
 

--- a/BlocksettleNetworkingLib/Wallets/SyncWallet.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWallet.h
@@ -47,6 +47,13 @@ namespace bs {
          virtual std::vector<std::string> securities() const = 0;
       };
 
+      enum class TxValidity : int
+      {
+         Unknown,
+         Valid,
+         Invalid,
+      };
+
       class Wallet;
 
       namespace wallet {
@@ -185,7 +192,7 @@ namespace bs {
          virtual BTCNumericTypes::balance_type getTxBalance(int64_t val) const { return val / BTCNumericTypes::BalanceDivider; }
          virtual QString displayTxValue(int64_t val) const;
          virtual QString displaySymbol() const { return QLatin1String("XBT"); }
-         virtual bool isTxValid(const BinaryData &) const { return true; }
+         virtual TxValidity isTxValid(const BinaryData &) const { return TxValidity::Valid; }
 
          // changeAddress must be set if there is change
          virtual core::wallet::TXSignRequest createTXRequest(const std::vector<UTXO> &

--- a/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.cpp
+++ b/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.cpp
@@ -1703,6 +1703,9 @@ void WalletsManager::startTracker(const std::string &cc)
    trackerSnapshots->setZcSnapshotUpdatedCb([this, cc] {
       checkTrackerUpdate(cc);
    });
+   trackerSnapshots->setReadyCb([this, cc] {
+      emit ccTrackerReady(cc);
+   });
 
    const auto tracker = std::make_shared<ColoredCoinTrackerClient>(std::move(trackerSnapshots));
    trackers_[cc] = tracker;

--- a/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
@@ -193,6 +193,7 @@ namespace bs {
          void walletImportFinished(const std::string &walletId);
          void newTransactions(std::vector<bs::TXEntry>) const;
          void invalidatedZCs(const std::set<BinaryData> &ids) const;
+         void ccTrackerReady(const std::string &cc);
 
       public slots:
          void onCCSecurityInfo(QString ccProd, QString ccDesc, unsigned long nbSatoshis, QString genesisAddr);


### PR DESCRIPTION
Return unknown state from sync::Wallet::isTxValid when CC tracker is not ready