### PR TITLE
Fix multiple chat key prompts

### DIFF
--- a/BlocksettleNetworkingLib/ChatProtocol/ClientDBLogic.cpp
+++ b/BlocksettleNetworkingLib/ChatProtocol/ClientDBLogic.cpp
@@ -644,7 +644,7 @@ void ClientDBLogic::checkRecipientPublicKey(const Chat::UniqieRecipientMap& uniq
             auto oldPublicKey = BinaryData::CreateFromHex(query.value(0).toString().toStdString());
             auto oldPublicKeyTimestamp = QDateTime::fromMSecsSinceEpoch(query.value(1).toULongLong());
 
-            if (recipientPtr->publicKey() != oldPublicKey || recipientPtr->publicKeyTime() != oldPublicKeyTimestamp)
+            if (recipientPtr->publicKey() != oldPublicKey)
             {
                const auto userPkPtr = std::make_shared<UserPublicKeyInfo>();
                userPkPtr->setUser_hash(QString::fromStdString(recipientPtr->userHash()));


### PR DESCRIPTION
Do not prompt when only chat pubkey timestamp changes