### PR TITLE
[WIP] WebSocket updates

### DIFF
--- a/BlocksettleNetworkingLib/ActiveStreamClient.cpp
+++ b/BlocksettleNetworkingLib/ActiveStreamClient.cpp
@@ -14,8 +14,7 @@
 
 #include <spdlog/spdlog.h>
 
-ActiveStreamClient::ActiveStreamClient(const std::shared_ptr<spdlog::logger> &logger
-   , const std::shared_ptr<bs::network::TransportClient> &) // unused atm
+ActiveStreamClient::ActiveStreamClient(const std::shared_ptr<spdlog::logger> &logger)
    : logger_(logger)
 {}
 

--- a/BlocksettleNetworkingLib/ActiveStreamClient.h
+++ b/BlocksettleNetworkingLib/ActiveStreamClient.h
@@ -41,7 +41,6 @@ public:
 
 protected:
    bool sendRawData(const std::string& data);
-   bool sendData(const std::string &data) { return send(data); }
    void notifyOnData(const std::string& data);
 
 protected:

--- a/BlocksettleNetworkingLib/ActiveStreamClient.h
+++ b/BlocksettleNetworkingLib/ActiveStreamClient.h
@@ -17,19 +17,13 @@
 namespace spdlog {
    class logger;
 }
-namespace bs {
-   namespace network {
-      class TransportClient;
-   }
-}
 
 class ZmqStreamServerConnection;
 
 class ActiveStreamClient
 {
 public:
-   ActiveStreamClient(const std::shared_ptr<spdlog::logger> &
-      , const std::shared_ptr<bs::network::TransportClient> &t = nullptr);
+   ActiveStreamClient(const std::shared_ptr<spdlog::logger> &);
    virtual ~ActiveStreamClient() noexcept = default;
 
    ActiveStreamClient(const ActiveStreamClient&) = delete;

--- a/BlocksettleNetworkingLib/ApplicationSettings.cpp
+++ b/BlocksettleNetworkingLib/ApplicationSettings.cpp
@@ -195,6 +195,7 @@ ApplicationSettings::ApplicationSettings(const QString &appName
       { AutoStartRFQScript,      SettingDef(QLatin1String("AutoStartRFQScript"), false) },
       { CurrentRFQScript,        SettingDef(QLatin1String("CurRFQScript")) },
       { ShowInfoWidget,          SettingDef(QLatin1String("ShowInfoWidget"), true) },
+      { LoginApiKey,             SettingDef(QLatin1String("LoginApiKey")) },
       { AutoQouting,             SettingDef(QLatin1String("AutoQuoting"), false) },
       { AutoSigning,             SettingDef(QLatin1String("AutoSigning"), false) }
    };

--- a/BlocksettleNetworkingLib/ApplicationSettings.h
+++ b/BlocksettleNetworkingLib/ApplicationSettings.h
@@ -145,6 +145,7 @@ public:
       AutoStartRFQScript,
       CurrentRFQScript,
       ShowInfoWidget,
+      LoginApiKey,
       AutoQouting,
       AutoSigning,
       _last

--- a/BlocksettleNetworkingLib/AuthAddressLogic.cpp
+++ b/BlocksettleNetworkingLib/AuthAddressLogic.cpp
@@ -65,14 +65,23 @@ void ValidationAddressACT::processNotification()
          break;
       }
 
+      const auto callbacks = callbacks_.lock();
+      if (!callbacks) {
+         break;
+      }
+
       switch (dbNotifPtr->type_) {
       case DBNS_NewBlock:
       case DBNS_ZC:
-         vamPtr_->update();
+         if (callbacks->onUpdate) {
+            callbacks->onUpdate();
+         }
          break;
 
       case DBNS_Refresh:
-         vamPtr_->pushRefreshID(dbNotifPtr->ids_);
+         if (callbacks->onRefresh) {
+            callbacks->onRefresh(dbNotifPtr->ids_);
+         }
          break;
 
       default:
@@ -84,7 +93,8 @@ void ValidationAddressACT::processNotification()
 ////
 void ValidationAddressACT::start()
 {
-   if (vamPtr_ == nullptr) {
+   const auto callbacks = callbacks_.lock();
+   if (!callbacks) {
       throw std::runtime_error("null validation address manager ptr");
    }
    auto thrLbd = [this](void)->void
@@ -105,28 +115,173 @@ void ValidationAddressACT::stop()
    }
 }
 
+
+void AuthValidatorCallbacks::setTarget(AuthAddressValidator *target)
+{
+   //don't overwrite existing target
+   if (!target || onUpdate) {
+      return;
+   }
+   onUpdate = [target] {target->update(); };
+   onRefresh = [target](const std::vector<BinaryData> &ids)
+   {
+      target->pushRefreshID(ids);
+   };
+}
+
+
+struct VAMLambdas : public AuthValidatorCallbacks
+{
+   explicit VAMLambdas(const std::shared_ptr<ArmoryConnection> &conn)
+      : connPtr(conn)
+   {
+      assert(conn);
+      const auto &wltId = CryptoPRNG::generateRandom(12);
+      walletObj_ = connPtr->instantiateWallet(wltId.toHexStr());
+   }
+
+   bool isInited() const override
+   {
+      return (connPtr && walletObj_);
+   }
+
+   std::string registerAddresses(const std::vector<bs::Address> &addrVec) override
+   {
+      std::vector<BinaryData> pfxAddrs;
+      pfxAddrs.reserve(addrVec.size());
+      for (const auto &addr : addrVec) {
+         pfxAddrs.push_back(addr.prefixed());
+      }
+      return walletObj_->registerAddresses(pfxAddrs, false);
+   }
+
+   unsigned int topBlock() const override
+   {
+      return connPtr->topBlock();
+   }
+
+   void pushZC(const BinaryData &tx) override
+   {
+      connPtr->pushZC(tx);
+   }
+
+   void getOutpointsForAddresses(const std::vector<bs::Address> &addrs
+      , const OutpointsCb &cb, unsigned int topBlock = 0
+      , unsigned int zcIndex = 0) override
+   {
+      const auto &opLbd = [this, cb](const OutpointBatch &batch)
+      {
+         if (cb) {
+            cb(batch);
+         }
+      };
+      std::vector<BinaryData> addrsPrefixed;
+      addrsPrefixed.reserve(addrs.size());
+      for (const auto &addr : addrs) {
+         addrsPrefixed.push_back(addr.prefixed());
+      }
+      connPtr->getOutpointsFor(addrsPrefixed, opLbd, topBlock, zcIndex);
+   }
+
+   void getSpendableTxOuts(const UTXOsCb &cb) override
+   {
+      if (!connPtr || (connPtr->state() != ArmoryState::Ready)) {
+         if (cb) {
+            cb({});
+         }
+         return;
+      }
+      const auto &spendableCb = [this, cb]
+         (ReturnMessage<std::vector<UTXO>> utxoVec)->void
+      {
+         try {
+            const auto& utxos = utxoVec.get();
+            if (cb) {
+               cb(utxos);
+            }
+         } catch (const std::exception &e) {
+            if (cb) {
+               cb({});
+            }
+         }
+      };
+      walletObj_->getSpendableTxOutListForValue(UINT64_MAX, spendableCb);
+   }
+
+   void getUTXOsForAddress(const bs::Address &addr, const UTXOsCb &cb
+      , bool withZC) override
+   {
+      auto utxoLbd = [this, cb](const std::vector<UTXO> &utxos)
+      {
+         if (cb) {
+            cb(utxos);
+         }
+      };
+      connPtr->getUTXOsForAddress(addr.prefixed(), utxoLbd, withZC);
+   }
+
+   std::shared_ptr<ArmoryConnection> connPtr;
+
+private:
+   std::shared_ptr<AsyncClient::BtcWallet> walletObj_;
+};
+
+
 ///////////////////////////////////////////////////////////////////////////////
 ValidationAddressManager::ValidationAddressManager(
-   std::shared_ptr<ArmoryConnection> conn) :
-   connPtr_(conn)
+   const std::shared_ptr<ArmoryConnection> &conn)
+   : AuthAddressValidator(std::make_shared<VAMLambdas>(conn))
+{}
+
+ValidationAddressManager::~ValidationAddressManager()
 {
-   ready_.store(false, std::memory_order_relaxed);
-   if (connPtr_) {
-      auto&& wltIdSbd = CryptoPRNG::generateRandom(12);
-      walletObj_ = connPtr_->instantiateWallet(wltIdSbd.toHexStr());
+   if (actPtr_ != nullptr) {
+      actPtr_->stop();
    }
 }
 
 ////
-void ValidationAddressManager::pushRefreshID(std::vector<BinaryData>& idVec)
+void ValidationAddressManager::setCustomACT(const
+   std::shared_ptr<ValidationAddressACT> &actPtr)
 {
-   for (auto& id : idVec) {
+   //have to set the ACT before going online
+   if (isReady()) {
+      throw std::runtime_error("ValidationAddressManager is already online");
+   }
+   if (lambdas_) {
+      actPtr_ = actPtr;
+      actPtr_->setCallbacks(lambdas_);
+      lambdas_->setTarget(this);
+      actPtr_->start();
+   }
+}
+
+void ValidationAddressManager::prepareCallbacks()
+{
+   //use default ACT if none is set
+   if (actPtr_) {
+      return;
+   }
+   const auto lambdas = std::dynamic_pointer_cast<VAMLambdas>(lambdas_);
+   if (lambdas) {
+      actPtr_ = std::make_shared<ValidationAddressACT>(lambdas->connPtr.get());
+
+      //set the act manager ptr to process notifications
+      actPtr_->setCallbacks(lambdas);
+      actPtr_->start();
+   }
+}
+
+////
+void AuthAddressValidator::pushRefreshID(const std::vector<BinaryData> &idVec)
+{
+   for (auto id : idVec) {
       refreshQueue_.push_back(std::move(id));
    }
 }
 
 ////
-void ValidationAddressManager::waitOnRefresh(const std::string& id)
+void AuthAddressValidator::waitOnRefresh(const std::string& id)
 {
    BinaryDataRef idRef;
    idRef.setRef(id);
@@ -140,234 +295,223 @@ void ValidationAddressManager::waitOnRefresh(const std::string& id)
 }
 
 ////
-void ValidationAddressManager::setCustomACT(const
-   std::shared_ptr<ValidationAddressACT> &actPtr)
+std::shared_ptr<ValidationAddressStruct>
+AuthAddressValidator::getValidationAddress(const bs::Address &addr) const
 {
-   //have to set the ACT before going online
+   auto iter = validationAddresses_.find(addr);
+   if (iter == validationAddresses_.end()) {
+      return nullptr;
+   }
+   //acquire to make sure we see update thread changes
+   auto ptrCopy = std::atomic_load_explicit(
+      &iter->second, std::memory_order_acquire);
+   return ptrCopy;
+}
+
+////
+void AuthAddressValidator::addValidationAddress(const bs::Address &addr)
+{
+   /*
+   goOnline should be called from the same thread that populates the 
+   list of validation address.
+   */
    if (ready_.load(std::memory_order_relaxed)) {
-      throw std::runtime_error("ValidationAddressManager is already online");
+      throw std::runtime_error("cannot modify validation address list "
+                              "after going online");
    }
-   actPtr_ = actPtr;
-   actPtr_->setAddressMgr(this);
-   actPtr_->start();
+   validationAddresses_[addr] = std::make_shared<ValidationAddressStruct>();
 }
 
 ////
-std::shared_ptr<ValidationAddressStruct> 
-ValidationAddressManager::getValidationAddress(
-   const BinaryData& addr)
-{
-   auto iter = validationAddresses_.find(addr);
-   if (iter == validationAddresses_.end()) {
-      return nullptr;
-   }
-   //acquire to make sure we see update thread changes
-   auto ptrCopy = std::atomic_load_explicit(
-      &iter->second, std::memory_order_acquire);
-   return ptrCopy;
-}
-
-////
-const std::shared_ptr<ValidationAddressStruct>
-ValidationAddressManager::getValidationAddress(
-   const BinaryData& addr) const
-{
-   auto iter = validationAddresses_.find(addr);
-   if (iter == validationAddresses_.end()) {
-      return nullptr;
-   }
-   //acquire to make sure we see update thread changes
-   auto ptrCopy = std::atomic_load_explicit(
-      &iter->second, std::memory_order_acquire);
-   return ptrCopy;
-}
-
-////
-void ValidationAddressManager::addValidationAddress(const bs::Address &addr)
-{
-   validationAddresses_.insert({ addr.prefixed()
-      , std::make_shared<ValidationAddressStruct>() });
-}
-
-////
-unsigned ValidationAddressManager::goOnline()
+bool AuthAddressValidator::goOnline(const ResultCb &cb)
 {  /*
    For the sake of simplicity, this assumes the BDV is already online.
    This process is therefor equivalent to registering the validation addresses,
    waiting for the notification and grabbing all txouts for each address.
 
-   Again, for the sake of simplicity, this method blocks untill the setup
+   Again, for the sake of simplicity, this method blocks until the setup
    is complete.
 
    You cannot change the validation address list post setup. You need to 
    destroy this object and create a new one with the updated list.
    */
 
-   if (!connPtr_ || !walletObj_) {
-      return 0;
+   if (!lambdas_ || !lambdas_->isInited()) {
+      return false;
    }
 
    //pthread_once behavior
    if (ready_.load(std::memory_order_relaxed)) {
-      return UINT32_MAX;
+      return true;
    }
-   //use default ACT is none is set
-   if (actPtr_ == nullptr) {
-      actPtr_ = std::make_shared<ValidationAddressACT>(connPtr_.get());
-
-      //set the act manager ptr to process notifications
-      actPtr_->setAddressMgr(this);
-      actPtr_->start();
-   }
+   prepareCallbacks();
+   lambdas_->setTarget(this);
 
    //register validation addresses
-   std::vector<BinaryData> addrVec;
-
+   std::vector<bs::Address> addrVec;
    for (auto& addrPair : validationAddresses_) {
       addrVec.push_back(addrPair.first);
    }
-   auto &&regID = walletObj_->registerAddresses(addrVec, false);
-   waitOnRefresh(regID);
+   const auto &regID = lambdas_->registerAddresses(addrVec);
 
-   auto aopCount = update();
+   std::thread([this, regID, cb] {
+      waitOnRefresh(regID);
 
-   //find & set first outpoints
-   for (auto& maPair : validationAddresses_) {
-      const auto& maStruct = *maPair.second.get();
+      update();
 
-      std::shared_ptr<AuthOutpoint> aopPtr;
-      BinaryDataRef txHash;
-      for (auto& hashPair : maStruct.outpoints_) {
-         for (auto& opPair : hashPair.second) {
-            if (*opPair.second < aopPtr) {
-               aopPtr = opPair.second;
-               txHash = hashPair.first.getRef();
+      //find & set first outpoints
+      for (auto& maPair : validationAddresses_) {
+         const auto& maStruct = *maPair.second.get();
+
+         std::shared_ptr<AuthOutpoint> aopPtr;
+         BinaryDataRef txHash;
+         for (auto& hashPair : maStruct.outpoints_) {
+            for (auto& opPair : hashPair.second) {
+               if (*opPair.second < aopPtr) {
+                  aopPtr = opPair.second;
+                  txHash = hashPair.first.getRef();
+               }
             }
          }
+
+         if (aopPtr == nullptr || aopPtr->isZc()) {
+            if (cb) {
+               cb(false);
+            }
+            throw AuthLogicException(
+               "validation address has no valid first outpoint");
+         }
+
+         maPair.second->firstOutpointHash_ = txHash;
+         maPair.second->firstOutpointIndex_ = aopPtr->txOutIndex();
       }
 
-      if (aopPtr == nullptr || aopPtr->isZc()) {
-         throw std::runtime_error(
-            "validation address has no valid first outpoint");
+      //set ready & return outpoint count
+      ready_.store(true, std::memory_order_relaxed);
+
+      if (cb) {
+         cb(true);
       }
-
-      maPair.second->firstOutpointHash_ = txHash;
-      maPair.second->firstOutpointIndex_ = aopPtr->txOutIndex();
-   }
-
-   //set ready & return outpoint count
-   ready_.store(true, std::memory_order_relaxed);
-   return aopCount;
+   }).detach();
+   return true;
 }
 
 ////
-unsigned ValidationAddressManager::update()
+unsigned AuthAddressValidator::update()
 {
-   std::vector<BinaryData> addrVec;
+   std::unique_lock<std::mutex> lock(updateMutex_);
+
+   if (!lambdas_) {
+      return 0;
+   }
+   std::vector<bs::Address> addrVec;
    for (auto& addrPair : validationAddresses_) {
       addrVec.push_back(addrPair.first);
    }
-   //keep track of txout changes in validation addresses since last seen block
-   auto promPtr = std::make_shared<std::promise<unsigned>>();
-   auto futPtr = promPtr->get_future();
-   auto opLbd = [this, promPtr](const OutpointBatch &batch)->void
-   {
-      unsigned opCount = 0;
-      for (auto& outpointPair : batch.outpoints_) {
-         auto& outpointVec = outpointPair.second;
-         if (outpointVec.size() == 0) {
+   const auto &batch = getOutpointsForAddresses(addrVec, topBlock_, zcIndex_);
+
+   unsigned opCount = 0;
+   for (auto& outpointPair : batch.outpoints_) {
+      auto& outpointVec = outpointPair.second;
+      if (outpointVec.size() == 0) {
+         continue;
+      }
+      opCount += outpointVec.size();
+
+      //create copy of validation address struct
+      auto updateValidationAddrStruct = std::make_shared<ValidationAddressStruct>();
+
+      //get existing address struct
+      auto maIter = validationAddresses_.find(bs::Address::fromPrefixed(outpointPair.first));
+      if (maIter != validationAddresses_.end()) {
+         /*
+         Copy the existing struct over to the new one.
+
+         While all notification based callers of update() come from the
+         same thread, it is called by goOnline() once, from a thread we
+         do not control, therefor the copy of the existing struct into
+         the new one is preceded by an acquire operation.
+         */
+         auto maStruct = std::atomic_load_explicit(
+            &maIter->second, std::memory_order_acquire);
+         *updateValidationAddrStruct = *maStruct;
+      } else {
+         //can't be missing a validation address
+         throw AuthLogicException("missing validation address");
+      }
+
+      //populate new outpoints
+      for (auto& op : outpointVec) {
+         auto aop = std::make_shared<AuthOutpoint>(
+            op.txHeight_, op.txIndex_, op.txOutIndex_,
+            op.value_, op.isSpent_, op.spenderHash_);
+
+         auto hashIter = updateValidationAddrStruct->outpoints_.find(op.txHash_);
+         if (hashIter == updateValidationAddrStruct->outpoints_.end()) {
+            hashIter = updateValidationAddrStruct->outpoints_.insert(std::make_pair(
+               op.txHash_,
+               std::map<unsigned, std::shared_ptr<AuthOutpoint>>())).first;
+         }
+
+         //update existing outpoints if the spent flag is set
+         auto fIter = hashIter->second.find(aop->txOutIndex());
+         if (fIter != hashIter->second.end()) {
+            aop->updateFrom(*fIter->second);
+
+            //remove spender hash entry as the ref will die after this swap
+            if (fIter->second->isSpent()) {
+               updateValidationAddrStruct->spenderHashes_.erase(
+                  fIter->second->spenderHash().getRef());
+            }
+            fIter->second = aop;
+            if (op.isSpent_) {
+               //set valid spender hash ref
+               updateValidationAddrStruct->spenderHashes_.insert(
+                  fIter->second->spenderHash().getRef());
+            }
             continue;
          }
-         opCount += outpointVec.size();
 
-         //create copy of validation address struct
-         auto updateValidationAddrStruct = std::make_shared<ValidationAddressStruct>();
-
-         //get existing address struct
-         auto maIter = validationAddresses_.find(outpointPair.first);
-         if (maIter != validationAddresses_.end()) {
-            /*
-            Copy the existing struct over to the new one.
-
-            While all notification based callers of update() come from the 
-            same thread, it is called by goOnline() once, from a thread we 
-            do not control, therefor the copy of the existing struct into 
-            the new one is preceded by an acquire operation.
-            */
-            auto maStruct = std::atomic_load_explicit(
-               &maIter->second, std::memory_order_acquire);
-            *updateValidationAddrStruct = *maStruct;
+         hashIter->second.emplace(std::make_pair(aop->txOutIndex(), aop));
+         if (op.isSpent_) {
+            //we can just insert the spender hash without worry, as it wont fail to
+            //replace an expiring reference
+            updateValidationAddrStruct->spenderHashes_.insert(aop->spenderHash().getRef());
          }
-         else {
-            //can't be missing a validation address
-            throw std::runtime_error("missing validation address");
-         }
-
-         //populate new outpoints
-         for (auto& op : outpointVec) {
-            auto aop = std::make_shared<AuthOutpoint>(
-               op.txHeight_, op.txIndex_, op.txOutIndex_,
-               op.value_, op.isSpent_, op.spenderHash_);
-
-            auto hashIter = updateValidationAddrStruct->outpoints_.find(op.txHash_);
-            if (hashIter == updateValidationAddrStruct->outpoints_.end()) {
-               hashIter = updateValidationAddrStruct->outpoints_.insert(std::make_pair(
-                  op.txHash_,
-                  std::map<unsigned, std::shared_ptr<AuthOutpoint>>())).first;
-            }
-
-            //update existing outpoints if the spent flag is set
-            auto fIter = hashIter->second.find(aop->txOutIndex());
-            if (fIter != hashIter->second.end()) {
-               aop->updateFrom(*fIter->second);
-
-               //remove spender hash entry as the ref will die after this swap
-               if (fIter->second->isSpent()) {
-                  updateValidationAddrStruct->spenderHashes_.erase(
-                     fIter->second->spenderHash().getRef());
-               }
-               fIter->second = aop;
-               if (op.isSpent_) {
-                  //set valid spender hash ref
-                  updateValidationAddrStruct->spenderHashes_.insert(
-                     fIter->second->spenderHash().getRef());
-               }
-               continue;
-            }
-
-            hashIter->second.emplace(std::make_pair(aop->txOutIndex(), aop));
-            if (op.isSpent_) {
-               //we can just insert the spender hash without worry, as it wont fail to
-               //replace an expiring reference
-               updateValidationAddrStruct->spenderHashes_.insert(aop->spenderHash().getRef());
-            }
-         }
-
-         //store with release semantics to make the changes visible to reader threads
-         std::atomic_store_explicit(
-            &maIter->second, updateValidationAddrStruct, std::memory_order_release);
       }
 
-      //update cutoffs
-      topBlock_ = batch.heightCutoff_ + 1;
-      zcIndex_ = batch.zcIndexCutoff_;
+      //store with release semantics to make the changes visible to reader threads
+      std::atomic_store_explicit(
+         &maIter->second, updateValidationAddrStruct, std::memory_order_release);
+   }
 
-      promPtr->set_value(opCount);
-   };
+   //update cutoffs
+   topBlock_ = batch.heightCutoff_ + 1;
+   zcIndex_ = batch.zcIndexCutoff_;
 
-   //grab all txouts
-   connPtr_->getOutpointsFor(addrVec, opLbd, topBlock_, zcIndex_);
-   checkFutureWait(futPtr);
-   return futPtr.get();
+   return opCount;
+}
+
+void AuthAddressValidator::update(const ResultCb &cb)
+{  // Async update to allow processing of messages while waiting for them at the same time
+   std::thread([this, cb] {
+      try {
+         update();
+         if (cb) {
+            cb(true);
+         }
+      }
+      catch (const AuthLogicException &) {
+         if (cb) {
+            cb(false);
+         }
+      }
+   }).detach();
 }
 
 ////
-bool ValidationAddressManager::isValid(const bs::Address& addr) const
-{
-   return isValid(addr.prefixed());
-}
 
-bool ValidationAddressManager::isValid(const BinaryData& addr) const
+bool AuthAddressValidator::isValidMasterAddress(const bs::Address &addr) const
 {
    auto maStructPtr = getValidationAddress(addr);
    if (maStructPtr == nullptr) {
@@ -375,7 +519,7 @@ bool ValidationAddressManager::isValid(const BinaryData& addr) const
    }
    auto firstOutpoint = maStructPtr->getFirsOutpoint();
    if (firstOutpoint == nullptr) {
-      throw std::runtime_error("uninitialized first output");
+      throw AuthLogicException("uninitialized first output");
    }
    if (!firstOutpoint->isValid()) {
       return false;
@@ -387,98 +531,24 @@ bool ValidationAddressManager::isValid(const BinaryData& addr) const
 }
 
 ////
-
-bool ValidationAddressManager::getOutpointBatch(const bs::Address &addr
-   , const std::function<void(const OutpointBatch &)> &cb) const
-{
-   if (!connPtr_) {
-      return false;
-   }
-   return connPtr_->getOutpointsFor({ addr }, cb);
-}
-
-bool ValidationAddressManager::getSpendableTxOutFor(const bs::Address &validationAddr
-   , const std::function<void(const UTXO &)> &cb, size_t nbOutputs) const
-{
-   if (!connPtr_ || (connPtr_->state() != ArmoryState::Ready)) {
-      return false;
-   }
-   auto spendableCb = [this, validationAddr, cb, nbOutputs](
-      ReturnMessage<std::vector<UTXO>> utxoVec)->void
-   {
-      try {
-         const auto& utxos = utxoVec.get();
-         if (utxos.empty()) {
-            throw AuthLogicException("no utxos available");
-         }
-         const auto utxo = getVettingUtxo(validationAddr, utxos, nbOutputs);
-         if (!utxo.isInitialized()) {
-            throw AuthLogicException("vetting UTXO is uninited");
-         }
-
-         if (cb) {
-            cb(utxo);
-         }
-      } catch (const std::exception &e) {
-         if (cb) {
-            cb({});
-         }
-      }
-   };
-   walletObj_->getSpendableTxOutListForValue(UINT64_MAX, spendableCb);
-   return true;
-}
-
-bool ValidationAddressManager::getVettingUTXOsFor(const bs::Address &validationAddr
-   , const std::function<void(const std::vector<UTXO> &)> &cb) const
-{
-   if (!connPtr_ || (connPtr_->state() != ArmoryState::Ready)) {
-      return false;
-   }
-   auto spendableCb = [this, validationAddr, cb](
-      ReturnMessage<std::vector<UTXO>> utxoVec)->void
-   {
-      try {
-         const auto& utxos = utxoVec.get();
-         if (utxos.empty()) {
-            throw AuthLogicException("no utxos available");
-         }
-         const auto vettingUtxos = filterVettingUtxos(validationAddr, utxos);
-         if (vettingUtxos.empty()) {
-            throw AuthLogicException("no vetting UTXOs found");
-         }
-
-         if (cb) {
-            cb(vettingUtxos);
-         }
-      } catch (const std::exception &) {
-         if (cb) {
-            cb({});
-         }
-      }
-   };
-   walletObj_->getSpendableTxOutListForValue(UINT64_MAX, spendableCb);
-   return true;
-}
-
-UTXO ValidationAddressManager::getVettingUtxo(const bs::Address &validationAddr
+UTXO AuthAddressValidator::getVettingUtxo(const bs::Address &validationAddr
    , const std::vector<UTXO> &utxos, size_t nbOutputs) const
 {
    const uint64_t amountThreshold = nbOutputs * kAuthValueThreshold + 1000;
    for (const auto& utxo : utxos) {
       //find the validation address for this utxo
-      auto scrAddr = utxo.getRecipientScrAddr();
+      const auto &addr = bs::Address::fromUTXO(utxo);
 
       //filter by desired validation address if one was provided
-      if (!validationAddr.empty() && (scrAddr != validationAddr.prefixed())) {
+      if (!validationAddr.empty() && (addr != validationAddr)) {
          continue;
       }
-      auto maStructPtr = getValidationAddress(scrAddr);
+      auto maStructPtr = getValidationAddress(addr);
       if (maStructPtr == nullptr) {
          continue;
       }
       //is validation address valid?
-      if (!isValid(scrAddr)) {
+      if (!isValidMasterAddress(addr)) {
          continue;
       }
       //The first utxo of a validation address isn't eligible to vet
@@ -497,25 +567,25 @@ UTXO ValidationAddressManager::getVettingUtxo(const bs::Address &validationAddr
    return {};
 }
 
-std::vector<UTXO> ValidationAddressManager::filterVettingUtxos(
+std::vector<UTXO> AuthAddressValidator::filterVettingUtxos(
    const bs::Address &validationAddr, const std::vector<UTXO> &utxos) const
 {
    std::vector<UTXO> result;
    const uint64_t amountThreshold = kAuthValueThreshold + 1000;
    for (const auto& utxo : utxos) {
       //find the validation address for this utxo
-      auto scrAddr = utxo.getRecipientScrAddr();
+      const auto &addr = bs::Address::fromUTXO(utxo);
 
       //filter by desired validation address if one was provided
-      if (!validationAddr.empty() && (scrAddr != validationAddr.prefixed())) {
+      if (!validationAddr.empty() && (addr != validationAddr)) {
          continue;
       }
-      auto maStructPtr = getValidationAddress(scrAddr);
+      auto maStructPtr = getValidationAddress(addr);
       if (maStructPtr == nullptr) {
          continue;
       }
       //is validation address valid?
-      if (!isValid(scrAddr)) {
+      if (!isValidMasterAddress(addr)) {
          continue;
       }
       //The first utxo of a validation address isn't eligible to vet
@@ -535,54 +605,35 @@ std::vector<UTXO> ValidationAddressManager::filterVettingUtxos(
 }
 
 ////
-BinaryData ValidationAddressManager::fundUserAddress(
+BinaryData AuthAddressValidator::fundUserAddress(
    const bs::Address& addr,
    std::shared_ptr<ResolverFeed> feedPtr,
    const bs::Address& validationAddr) const
-{  /*
-   To vet a user address, send it coins from a validation address.
-   */
-
-   auto promPtr = std::make_shared<std::promise<bool>>();
-   auto fut = promPtr->get_future();
-   auto outpointCb = [promPtr](const OutpointBatch &batch)->void
-   {
-      if (batch.outpoints_.size() > 0) {
-         promPtr->set_value(false);
-      }
-      else {
-         promPtr->set_value(true);
-      }
-   };
-
-   getOutpointBatch(addr, outpointCb);
-   checkFutureWait(fut);
-   if (!fut.get()) {
+{
+   if (!lambdas_) {
+      throw std::runtime_error("no lambdas set");
+   }
+   const auto &opBatch = getOutpointsForAddresses({ addr });
+   if (!opBatch.outpoints_.empty()) {
       throw AuthLogicException("can only vet virgin user addresses");
    }
 
    std::unique_lock<std::mutex> lock(vettingMutex_);
 
    //#2: grab a utxo from a validation address
-   auto promPtr2 = std::make_shared<std::promise<UTXO>>();
-   auto fut2 = promPtr2->get_future();
-   auto spendableCb = [this, promPtr2](const UTXO &utxo)
-   {
-      promPtr2->set_value(utxo);
-   };
-   getSpendableTxOutFor(validationAddr, spendableCb);
 
-   checkFutureWait(fut2);
-   const auto utxo = fut2.get();
+   const auto &utxos = getSpendableTxOuts();
+   const auto utxo = getVettingUtxo(validationAddr, utxos);
    if (!utxo.isInitialized()) {
-      throw AuthLogicException("could not select a utxo to vet with");
+      throw AuthLogicException("missing vetting UTXO");
    }
+
    return fundUserAddress(addr, feedPtr, utxo);
 }
 
 // fundUserAddress was divided because actual signing will be performed
 // in OT which doesn't have access to ArmoryConnection
-BinaryData ValidationAddressManager::fundUserAddress(
+BinaryData AuthAddressValidator::fundUserAddress(
    const bs::Address& addr,
    std::shared_ptr<ResolverFeed> feedPtr,
    const UTXO &vettingUtxo) const
@@ -598,8 +649,8 @@ BinaryData ValidationAddressManager::fundUserAddress(
    //vetting output
    signer.addRecipient(addr.getRecipient(bs::XBTAmount{ kAuthValueThreshold }));
 
-   const auto scrAddr = vettingUtxo.getRecipientScrAddr();
-   const auto addrIter = validationAddresses_.find(scrAddr);
+   const auto &vettingAddr = bs::Address::fromUTXO(vettingUtxo);
+   const auto addrIter = validationAddresses_.find(vettingAddr);
    if (addrIter == validationAddresses_.end()) {
       throw AuthLogicException("input addr not found in validation addresses");
    }
@@ -619,7 +670,7 @@ BinaryData ValidationAddressManager::fundUserAddress(
    return signer.serializeSignedTx();
 }
 
-BinaryData ValidationAddressManager::fundUserAddresses(
+BinaryData AuthAddressValidator::fundUserAddresses(
    const std::vector<bs::Address> &addrs
    , const bs::Address &validationAddress
    , std::shared_ptr<ResolverFeed> feedPtr
@@ -639,8 +690,8 @@ BinaryData ValidationAddressManager::fundUserAddresses(
       auto spenderPtr = std::make_shared<ScriptSpender>(vettingUtxo);
       signer.addSpender(spenderPtr);
 
-      const auto scrAddr = vettingUtxo.getRecipientScrAddr();
-      const auto addrIter = validationAddresses_.find(scrAddr);
+      const auto &addr = bs::Address::fromUTXO(vettingUtxo);
+      const auto &addrIter = validationAddresses_.find(addr);
       if (addrIter == validationAddresses_.end()) {
          throw AuthLogicException("input addr not found in validation addresses");
       }
@@ -661,26 +712,30 @@ BinaryData ValidationAddressManager::fundUserAddresses(
    return signer.serializeSignedTx();
 }
 
-BinaryData ValidationAddressManager::vetUserAddress(
-   const bs::Address& addr,
-   std::shared_ptr<ResolverFeed> feedPtr,
-   const bs::Address& validationAddr) const
+BinaryData AuthAddressValidator::vetUserAddress(const bs::Address& addr
+   , std::shared_ptr<ResolverFeed> feedPtr, const bs::Address& validationAddr) const
 {
+   if (!lambdas_) {
+      throw std::runtime_error("no lambdas set");
+   }
    const auto signedTx = fundUserAddress(addr, feedPtr, validationAddr);
 
    //broadcast the zc
-   connPtr_->pushZC(signedTx);
+   lambdas_->pushZC(signedTx);
 
    Tx txObj(signedTx);
    return txObj.getThisHash();
 }
 
 ////
-BinaryData ValidationAddressManager::revokeValidationAddress(
+BinaryData AuthAddressValidator::revokeValidationAddress(
    const bs::Address& addr, std::shared_ptr<ResolverFeed> feedPtr) const
 {  /*
    To revoke a validation address, spend its first UTXO.
    */
+   if (!lambdas_) {
+      throw std::runtime_error("no lambdas set");
+   }
 
    //find the MA
    auto maStructPtr = getValidationAddress(addr);
@@ -690,36 +745,22 @@ BinaryData ValidationAddressManager::revokeValidationAddress(
    std::unique_lock<std::mutex> lock(vettingMutex_);
 
    //grab UTXOs
-   auto promPtr = std::make_shared<std::promise<UTXO>>();
-   auto fut = promPtr->get_future();
-   auto spendableCb = [this, promPtr, maStructPtr]
-      (ReturnMessage<std::vector<UTXO>> utxoVec)->void
-   {
-      try {
-         const auto& utxos = utxoVec.get();
-         if (utxos.size() == 0) {
-            throw AuthLogicException("no utxo to revoke");
-         }
+   const auto &utxos = getSpendableTxOuts();
+   if (utxos.size() == 0) {
+      throw AuthLogicException("no utxo to revoke");
+   }
 
-         for (const auto& utxo : utxos) {
-            if (!maStructPtr->isFirstOutpoint(
-               utxo.getTxHash(), utxo.getTxOutIndex())) {
-               continue;
-            }
-            promPtr->set_value(utxo);
-            return;
-         }
-
-         throw AuthLogicException("could not select first outpoint");
+   UTXO firstUtxo;
+   for (const auto &utxo : utxos) {
+      if (maStructPtr->isFirstOutpoint(
+         utxo.getTxHash(), utxo.getTxOutIndex())) {
+         firstUtxo = utxo;
+         break;
       }
-      catch (const std::exception &) {
-         promPtr->set_exception(std::current_exception());
-      }
-   };
-
-   walletObj_->getSpendableTxOutListForValue(UINT64_MAX, spendableCb);
-   checkFutureWait(fut);
-   auto&& firstUtxo = fut.get();
+   }
+   if (!firstUtxo.isInitialized()) {
+      throw AuthLogicException("could not select first outpoint");
+   }
 
    //spend it
    Signer signer;
@@ -740,74 +781,56 @@ BinaryData ValidationAddressManager::revokeValidationAddress(
       throw AuthLogicException("failed to sign");
    }
    //broadcast the zc
-   connPtr_->pushZC(signedTx);
+   lambdas_->pushZC(signedTx);
 
    Tx txObj(signedTx);
    return txObj.getThisHash();
 }
 
-BinaryData ValidationAddressManager::revokeUserAddress(
+BinaryData AuthAddressValidator::revokeUserAddress(
    const bs::Address& addr, std::shared_ptr<ResolverFeed> feedPtr)
 {
    /*
    To revoke a user address from a validation address, send it coins from
    its own validation address.
    */
+   if (!lambdas_) {
+      throw std::runtime_error("no lambdas set");
+   }
 
    //1: find validation address vetting this address
-   size_t foo;
-   auto paths = AuthAddressLogic::getValidPaths(*this, addr, foo);
-   if (paths.size() != 1) {
-      throw AuthLogicException("invalid user auth address");
-   }
-   auto& validationAddr = findValidationAddressForTxHash(paths[0].txHash_);
-   if (validationAddr.empty()) {
-      throw AuthLogicException("invalidated validation address");
-   }
+   auto paths = AuthAddressLogic::getAddrPathsStatus(*this, addr);
+   const auto& validatoinOutpoint = paths.getValidationOutpoint();
+
+   //this will throw if the validation address can't be found
+   auto& validationAddr = 
+      findValidationAddressForTxHash(validatoinOutpoint.txHash_);
    auto validationAddrPtr = getValidationAddress(validationAddr);
 
    std::unique_lock<std::mutex> lock(vettingMutex_);
 
    //2: get utxo from the validation address
-   auto promPtr = std::make_shared<std::promise<UTXO>>();
-   auto fut = promPtr->get_future();
-   auto utxoLbd = [this, promPtr, validationAddrPtr](
-      const std::vector<UTXO> &utxos)->void
-   {
-      try {
-         if (utxos.empty()) {
-            throw AuthLogicException("no utxos to revoke with");
-         }
-         for (const auto& utxo : utxos) {
-            //cannot use the validation address first utxo
-            if (validationAddrPtr->isFirstOutpoint(
-               utxo.getTxHash(), utxo.getTxOutIndex())) {
-               continue;
-            }
-            if (utxo.getValue() < kAuthValueThreshold + 1000ULL) {
-               continue;
-            }
-            promPtr->set_value(utxo);
-            return;
-         }
-
-         throw AuthLogicException("could not select utxo to revoke with");
+   const auto &utxos = getUTXOsForAddress(validationAddr);
+   UTXO addrUtxo;
+   for (const auto &utxo : utxos) {
+      //cannot use the validation address first utxo
+      if (validationAddrPtr->isFirstOutpoint(
+         utxo.getTxHash(), utxo.getTxOutIndex())) {
+         continue;
       }
-      catch (const std::exception &) {
-         promPtr->set_exception(std::current_exception());
+      if (utxo.getValue() < kAuthValueThreshold + 1000ULL) {
+         continue;
       }
-   };
-
-   connPtr_->getUTXOsForAddress(validationAddr, utxoLbd);
-   checkFutureWait(fut);
-   auto&& utxo = fut.get();
+      addrUtxo = utxo;
+      break;
+   }
 
    //3: spend to the user address
    Signer signer;
    signer.setFeed(feedPtr);
 
    //spender
-   auto spenderPtr = std::make_shared<ScriptSpender>(utxo);
+   auto spenderPtr = std::make_shared<ScriptSpender>(addrUtxo);
    signer.addSpender(spenderPtr);
 
    //revocation output
@@ -815,7 +838,7 @@ BinaryData ValidationAddressManager::revokeUserAddress(
 
    //change
    {
-      const bs::XBTAmount changeAmount{ utxo.getValue() - kAuthValueThreshold - 1000 };
+      const bs::XBTAmount changeAmount{ addrUtxo.getValue() - kAuthValueThreshold - 1000 };
       auto addrObj = bs::Address::fromHash(validationAddr);
       signer.addRecipient(addrObj.getRecipient(changeAmount));
    }
@@ -825,16 +848,16 @@ BinaryData ValidationAddressManager::revokeUserAddress(
    auto signedTx = signer.serializeSignedTx();
 
    //broadcast the zc
-   connPtr_->pushZC(signedTx);
+   lambdas_->pushZC(signedTx);
 
    Tx txObj(signedTx);
    return txObj.getThisHash();
 }
 
 ////
-bool ValidationAddressManager::hasSpendableOutputs(const bs::Address& addr) const
+bool AuthAddressValidator::hasSpendableOutputs(const bs::Address& addr) const
 {
-   auto& maStruct = getValidationAddress(addr);
+   const auto& maStruct = getValidationAddress(addr);
 
    for (auto& outpointSet : maStruct->outpoints_) {
       for (auto& outpoint : outpointSet.second) {
@@ -853,11 +876,11 @@ bool ValidationAddressManager::hasSpendableOutputs(const bs::Address& addr) cons
 }
 
 ////
-bool ValidationAddressManager::hasZCOutputs(const bs::Address& addr) const
+bool AuthAddressValidator::hasZCOutputs(const bs::Address& addr) const
 {
-   auto iter = validationAddresses_.find(addr.prefixed());
+   auto iter = validationAddresses_.find(addr);
    if (iter == validationAddresses_.end()) {
-      throw std::runtime_error("unknown validation address");
+      throw AuthLogicException("unknown validation address");
    }
    for (auto& outpointSet : iter->second->outpoints_) {
       for (auto& outpoint : outpointSet.second) {
@@ -870,14 +893,14 @@ bool ValidationAddressManager::hasZCOutputs(const bs::Address& addr) const
 }
 
 ////
-const BinaryData& ValidationAddressManager::findValidationAddressForUTXO(
+const bs::Address &AuthAddressValidator::findValidationAddressForUTXO(
    const UTXO& utxo) const
 {
    return findValidationAddressForTxHash(utxo.getTxHash());
 }
 
 ////
-const BinaryData& ValidationAddressManager::findValidationAddressForTxHash(
+const bs::Address &AuthAddressValidator::findValidationAddressForTxHash(
    const BinaryData& txHash) const
 {
    for (auto& maPair : validationAddresses_) {
@@ -887,56 +910,141 @@ const BinaryData& ValidationAddressManager::findValidationAddressForTxHash(
       }
       return maPair.first;
    }
-   throw std::runtime_error("no validation address spends to that hash");
+   throw AuthLogicException("no validation address spends to that hash");
 }
 
-///////////////////////////////////////////////////////////////////////////////
-std::vector<OutpointData> AuthAddressLogic::getValidPaths(
-   const ValidationAddressManager& vam, const bs::Address& addr, size_t &nbPaths)
+unsigned int AuthAddressValidator::topBlock() const
 {
-   std::vector<OutpointData> validPaths;
-   nbPaths = 0;
+   return lambdas_ ? lambdas_->topBlock() : UINT32_MAX;
+}
+
+OutpointBatch AuthAddressValidator::getOutpointsFor(const bs::Address &addr) const
+{
+   return getOutpointsForAddresses({ addr });
+}
+
+std::vector<UTXO> AuthAddressValidator::getUTXOsFor(const bs::Address &addr
+   , bool withZC) const
+{
+   return getUTXOsForAddress(addr, withZC);
+}
+
+void AuthAddressValidator::pushZC(const BinaryData &tx) const
+{
+   if (lambdas_) {
+      lambdas_->pushZC(tx);
+   }
+}
+
+OutpointBatch AuthAddressValidator::getOutpointsForAddresses(const std::vector<bs::Address> &addrs
+   , unsigned int topBlock, unsigned int zcIndex) const
+{
+   if (!lambdas_) {
+      return {};
+   }
+   //keep track of txout changes in validation addresses since last seen block
+   auto promPtr = std::make_shared<std::promise<OutpointBatch>>();
+   auto futPtr = promPtr->get_future();
+   const auto &opLbd = [this, promPtr](const OutpointBatch &batch)
+   {
+      promPtr->set_value(batch);
+   };
+   //grab all txouts
+   lambdas_->getOutpointsForAddresses(addrs, opLbd, topBlock, zcIndex);
+   checkFutureWait(futPtr);
+   return futPtr.get();
+}
+
+std::vector<UTXO> AuthAddressValidator::getSpendableTxOuts() const
+{
+   if (!lambdas_) {
+      throw std::runtime_error("no lambdas set");
+   }
+   auto promPtr = std::make_shared<std::promise<std::vector<UTXO>>>();
+   auto fut = promPtr->get_future();
+
+   const auto &spendableCb = [this, promPtr]
+   (const std::vector<UTXO> &utxos)->void
+   {
+      promPtr->set_value(utxos);
+   };
+   lambdas_->getSpendableTxOuts(spendableCb);
+   checkFutureWait(fut);
+
+   const auto &utxos = fut.get();
+   if (utxos.empty()) {
+      throw AuthLogicException("no utxos available");
+   }
+   return utxos;
+}
+
+std::vector<UTXO> AuthAddressValidator::getUTXOsForAddress(const bs::Address &addr
+   , bool withZC) const
+{
+   if (!lambdas_) {
+      return {};
+   }
+   auto promPtr = std::make_shared<std::promise<std::vector<UTXO>>>();
+   auto fut = promPtr->get_future();
+   auto utxoLbd = [this, promPtr](const std::vector<UTXO> &utxos)
+   {
+      promPtr->set_value(utxos);
+   };
+   lambdas_->getUTXOsForAddress(addr, utxoLbd, withZC);
+   checkFutureWait(fut);
+
+   const auto &utxos = fut.get();
+   if (utxos.empty()) {
+      throw AuthLogicException("no UTXOs");
+   }
+   return utxos;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+AuthAddressLogic::AddrPathsStatus AuthAddressLogic::getAddrPathsStatus(
+   const AuthAddressValidator &aav, const bs::Address &addr)
+{
+   /*
+   This code can be sped up for revoked/invalidated addresses by returning at 
+   the first fail condition. It returns the full path status at the moment.
+   */
+
+   AuthAddressLogic::AddrPathsStatus paths;
 
    //get txout history for address
-   auto promPtr = std::make_shared<std::promise<
-      std::map<BinaryData, std::vector<OutpointData>>>>();
-   auto futPtr = promPtr->get_future();
-   auto opLbd = [promPtr](const OutpointBatch &outpointBatch)
-   {
-      promPtr->set_value(outpointBatch.outpoints_);
-   };
-   if (!vam.connPtr()->getOutpointsFor({ addr }, opLbd)) {
-      promPtr->set_value({});
+   const auto &opMap = aav.getOutpointsFor(addr).outpoints_;
+   if (opMap.size() == 0) {
+      //no data for this address
+      paths.pathCount_ = 0;
+      return paths;
    }
-
-   checkFutureWait(futPtr);
-   //sanity check on the address history
-   auto&& opMap = futPtr.get();
-   if (opMap.size() != 1) {
-      throw AuthLogicException(
-         "unexpected result from getOutpointsForAddresses");
+   else if (opMap.size() != 1) {
+      //this is an error state, don't initialize the path
+      return paths;
    }
 
    auto& opVec = opMap.begin()->second;
-   nbPaths = opVec.size();
+   paths.pathCount_ = opVec.size();
 
    //check all spent outputs vs ValidationAddressManager
-   for (auto& outpoint : opVec) {
+   for (unsigned i=0; i<opVec.size(); i++) {
+      auto& outpoint = opVec[i];
       try {
          /*
          Does this txHash spend from a validation address output? It will
          throw if not.
          */
          auto& validationAddr = 
-            vam.findValidationAddressForTxHash(outpoint.txHash_);
+            aav.findValidationAddressForTxHash(outpoint.txHash_);
 
          /*
          If relevant validation address is invalid, this address is invalid,
          regardless of any other path states.
          */
-         if (!vam.isValid(validationAddr)) {
-            throw AuthLogicException(
-               "Address is vetted by invalid validation address");
+         if (!aav.isValidMasterAddress(validationAddr)) {
+            paths.invalidPaths_.push_back(i);
+            continue;
          }
 
          /*
@@ -944,74 +1052,101 @@ std::vector<OutpointData> AuthAddressLogic::getValidPaths(
          address.
          */
          if (outpoint.isSpent_) {
-            throw AuthLogicException(
-               "Address has been revoked");
+            paths.revokedPaths_.push_back(i);
+            continue;
          }
 
-         validPaths.push_back(outpoint);
+         paths.validPaths_.emplace(i, std::move(outpoint));
       }
-      catch (const std::exception &) {
+      catch (const AuthLogicException &) {
          continue;
       }
    }
+   return paths;
+}
 
-   return validPaths;
+////////////////////////////////////////////////////////////////////////////////
+bool AuthAddressLogic::isValid(
+   const AuthAddressValidator &aav, const bs::Address &addr)
+{
+   return (getAuthAddrState(aav, addr) == AddressVerificationState::Verified);
 }
 
 ////
 AddressVerificationState AuthAddressLogic::getAuthAddrState(
-   const ValidationAddressManager& vam, const bs::Address& addr)
+   const AuthAddressValidator &aav, const bs::Address& addr)
 {  /***
    Validity is unique. This means there should be only one output chain
    defining validity. Any concurent path, whether partial or full,
    invalidates the user address.
    ***/
 
-   auto currentTop = vam.connPtr()->topBlock();
+   auto currentTop = aav.topBlock();
    if (currentTop == UINT32_MAX) {
       throw std::runtime_error("invalid top height");
    }
 
    try {
-      size_t nbPaths = 0;
-      auto&& validPaths = getValidPaths(vam, addr, nbPaths);
+      auto&& pathState = getAddrPathsStatus(aav, addr);
+      if (!pathState.isInitialized()) {
+         throw std::runtime_error("uninitialized path state, "
+            "this happens on corrupt data from db");
+      }
 
-      //is there only 1 valid path?
-      if (validPaths.empty()) {
-         return (nbPaths > 0) ? AddressVerificationState::Revoked
-            : AddressVerificationState::NotSubmitted;
-      }
-      else if (validPaths.size() > 1) {
-         return AddressVerificationState::Revoked;
-      }
-      auto& outpoint = validPaths[0];
+      try {
+         //grab the outpoint for the validation path
+         const auto& outpoint = pathState.getValidationOutpoint();
 
-      //does this path have enough confirmations?
-      auto opHeight = outpoint.txHeight_;
-      if (currentTop >= opHeight &&
-         (1 + currentTop - opHeight) >= VALIDATION_CONF_COUNT) {
-         return AddressVerificationState::Verified;
+         //does it have enough confirmations?
+         auto opHeight = outpoint.txHeight_;
+         if (currentTop >= opHeight &&
+            (1 + currentTop - opHeight) >= VALIDATION_CONF_COUNT) {
+            return AddressVerificationState::Verified;
+         }
+         return AddressVerificationState::Verifying;
       }
-      return AddressVerificationState::PendingVerification;
+      catch (const AuthLogicException&) {
+         //failed to grab the validation output, this address is invalid
+
+         if (pathState.pathCount_ == 0) {
+            //address has no history
+            return AddressVerificationState::Virgin;
+         }
+
+         if (!pathState.invalidPaths_.empty()) {
+            //has a validation output from a revoked validation address
+            return AddressVerificationState::Invalidated_Implicit;
+         }
+
+         if (pathState.validPaths_.size() > 1) {
+            //has multiple validation outputs (we explicitly revoked this)
+            return AddressVerificationState::Invalidated_Explicit;
+         }
+
+         if (!pathState.revokedPaths_.empty()) {
+            //validation output was spent by user
+            return AddressVerificationState::Revoked;
+         }
+
+         //address has history and no validation outputs
+         return AddressVerificationState::Tainted;
+      }
    }
    catch (const AuthLogicException &) { }
 
-   return AddressVerificationState::NotSubmitted;
+   //logic error in getAddrPathsStatus, cannot proceed 
+   return AddressVerificationState::VerificationFailed;
 }
 
-////
+////////////////////////////////////////////////////////////////////////////////
 std::pair<bs::Address, UTXO> AuthAddressLogic::getRevokeData(
-   const ValidationAddressManager &vam, const bs::Address &addr)
+   const AuthAddressValidator &aav, const bs::Address &addr)
 {
    //get valid paths for address
-   size_t foo;
-   auto&& validPaths = getValidPaths(vam, addr, foo);
+   auto addrState = getAddrPathsStatus(aav, addr);
 
    //is there only 1 valid path?
-   if (validPaths.size() != 1) {
-      throw AuthLogicException("address has no valid paths");
-   }
-   auto& outpoint = validPaths[0];
+   const auto& outpoint = addrState.getValidationOutpoint();
 
    /*
    We do not check auth output maturation when revoking.
@@ -1019,57 +1154,41 @@ std::pair<bs::Address, UTXO> AuthAddressLogic::getRevokeData(
    */
 
    //grab UTXOs for address
-   auto promPtr = std::make_shared<std::promise<UTXO>>();
-   auto fut = promPtr->get_future();
-   auto utxosLbd = [&outpoint, promPtr]
-   (const std::vector<UTXO> utxos)->void
-   {
-      try {
-         if (utxos.empty()) {
-            throw std::runtime_error("no UTXOs found");
-         }
-         for (auto& utxo : utxos) {
-            if (utxo.getTxHash() == outpoint.txHash_ &&
-               utxo.getTxOutIndex() == outpoint.txOutIndex_) {
-               promPtr->set_value(utxo);
-               return;
-            }
-         }
-
-         /*
-         Throw if we can't find the outpoint to revoke within the
-         address' utxos, as this indicates our auth state is
-         corrupt.
-         */
-         throw std::runtime_error("could not find utxo to revoke");
-      } catch (const std::exception_ptr &e) {
-         promPtr->set_exception(e);
+   const auto &utxos = aav.getUTXOsFor(addr, true);
+   UTXO revokeUtxo;
+   for (auto& utxo : utxos) {
+      if (utxo.getTxHash() == outpoint.txHash_ &&
+         utxo.getTxOutIndex() == outpoint.txOutIndex_) {
+         revokeUtxo = utxo;
+         break;
       }
-   };
+   }
 
-   vam.connPtr()->getUTXOsForAddress(addr, utxosLbd, true);
-   checkFutureWait(fut);
-   auto&& revokeUtxo = fut.get();
+   if (!revokeUtxo.isInitialized()) {
+      throw AuthLogicException("missing validation utxo to revoke user address with");
+   }
 
    //we're sending the coins back to the relevant validation address
-   auto& validationAddr = vam.findValidationAddressForUTXO(revokeUtxo);
+   auto& validationAddr = aav.findValidationAddressForUTXO(revokeUtxo);
    auto addrObj = bs::Address::fromHash(validationAddr);
    return { addrObj, revokeUtxo };
 }
 
-BinaryData AuthAddressLogic::revoke(const ValidationAddressManager& vam,
-   const bs::Address& addr, std::shared_ptr<ResolverFeed> feedPtr)
+////
+BinaryData AuthAddressLogic::revoke(const AuthAddressValidator &aav,
+   const bs::Address &addr, const std::shared_ptr<ResolverFeed> &feedPtr)
 {
-   const auto revokeData = getRevokeData(vam, addr);
+   const auto revokeData = getRevokeData(aav, addr);
    const auto signedTx = revoke(addr, feedPtr, revokeData.first, revokeData.second);
 
    //sign and broadcast, return the txHash
    Tx txObj(signedTx);
-   vam.connPtr()->pushZC(signedTx);
+   aav.pushZC(signedTx);
 
    return txObj.getThisHash();
 }
 
+////
 BinaryData AuthAddressLogic::revoke(const bs::Address &
    , const std::shared_ptr<ResolverFeed> &feedPtr
    , const bs::Address &, const UTXO &revokeUtxo)
@@ -1079,36 +1198,50 @@ BinaryData AuthAddressLogic::revoke(const bs::Address &
    signer.setFeed(feedPtr);
    signer.addSpender(std::make_shared<ScriptSpender>(revokeUtxo));
 
-   const std::string opReturnMsg = "BlockSettle Terminal revoke";
+   //don't waste space, OP_RETURNs are useless to the chain
+   const std::string opReturnMsg = "BSTrevoke";
    signer.addRecipient(std::make_shared<Recipient_OPRETURN>(BinaryData::fromString(opReturnMsg)));
 
    signer.sign();
    return signer.serializeSignedTx();
 }
 
-std::vector<UTXO> ValidationAddressManager::filterAuthFundingUTXO(const std::vector<UTXO>& authInputs)
+////////////////////////////////////////////////////////////////////////////////
+bool AuthAddressLogic::AddrPathsStatus::isInitialized() const
 {
-   std::vector<UTXO> result;
+   return pathCount_ != UINT32_MAX;
+}
 
-   for (const auto& utxo : authInputs) try {
-      const auto authAddr = utxo.getRecipientScrAddr();
-      auto maStructPtr = getValidationAddress(authAddr);
-      if (maStructPtr == nullptr) {
-         continue;
+////
+bool AuthAddressLogic::AddrPathsStatus::isValid() const
+{
+   //if there are no invalid or revoked paths
+   if (invalidPaths_.empty() && revokedPaths_.empty()) {
+      
+      //and we have exactly 1 valid path
+      if (validPaths_.size() != 1) {
+         return false;
       }
 
-      if (!isValid(authAddr)) {
-         continue;
+      //and it is the first output on the address
+      auto pathIter = validPaths_.find(0);
+      if (pathIter != validPaths_.end()) {
+         return true;
       }
-
-      if (maStructPtr->isFirstOutpoint(utxo.getTxHash(), utxo.getTxOutIndex())) {
-         continue;
-      }
-
-      result.emplace_back(utxo);
-   } catch (...) {
-      continue;
    }
 
-   return result;
+   return false;
+}
+
+////
+const OutpointData& AuthAddressLogic::AddrPathsStatus::getValidationOutpoint() const
+{
+   if (!isValid())
+      throw AuthLogicException("addr isn't valid");
+
+   auto iter = validPaths_.find(0);
+   if (iter == validPaths_.end())
+      throw AuthLogicException("validation logic inconsistency");
+
+   return iter->second;
 }

--- a/BlocksettleNetworkingLib/AuthAddressLogic.h
+++ b/BlocksettleNetworkingLib/AuthAddressLogic.h
@@ -35,8 +35,6 @@ class ValidationAddressManager;
 
 struct AuthOutpoint
 {
-   friend class ValidationAddressManager;
-
 private:
    unsigned txOutIndex_ = UINT32_MAX;
    uint64_t value_ = UINT64_MAX;
@@ -47,7 +45,7 @@ private:
    mutable bool isSpent_ = true;
    mutable BinaryData spenderHash_;
 
-private:
+public:
    bool operator<(const std::shared_ptr<AuthOutpoint>& rhs) const
    {  /*
       Doesnt work for comparing zc with zc, works with. Works
@@ -71,7 +69,6 @@ private:
       return txOutIndex_ < rhs->txOutIndex_;
    }
 
-public:
    AuthOutpoint(
       unsigned txHeight, unsigned txIndex, unsigned txOutIndex,
       uint64_t value, bool isSpent,
@@ -125,6 +122,7 @@ public:
    }
 };
 
+struct AuthValidatorCallbacks;
 ////
 class ValidationAddressACT : public ArmoryCallbackTarget
 {
@@ -147,7 +145,7 @@ public:
    ////
    virtual void start();
    virtual void stop();
-   virtual void setAddressMgr(ValidationAddressManager* vamPtr) { vamPtr_ = vamPtr; }
+   virtual void setCallbacks(const std::shared_ptr<AuthValidatorCallbacks> &cbs) { callbacks_ = cbs; }
 
 private:
    void processNotification(void);
@@ -156,12 +154,18 @@ private:
    ArmoryThreading::BlockingQueue<std::shared_ptr<DBNotificationStruct>> notifQueue_;
    std::thread processThr_;
 
-   ValidationAddressManager* vamPtr_ = nullptr;
+protected:
+   std::weak_ptr<AuthValidatorCallbacks>  callbacks_;
 };
 
 ////
 struct ValidationAddressStruct
 {
+   /*
+   Validation and master addresses are 2 names for the same thing. 
+   Master/Validation addresses are used to validate user addreses.
+   */
+
    //<tx hash, <txoutid, outpoint>>
    std::map<BinaryData,
       std::map<unsigned, std::shared_ptr<AuthOutpoint>>> outpoints_;
@@ -199,8 +203,35 @@ struct ValidationAddressStruct
    }
 };
 
-////
-class ValidationAddressManager
+
+class AuthAddressValidator;
+struct AuthValidatorCallbacks
+{
+   virtual void shutdown() {}
+   virtual bool isInited() const { return true; }
+   virtual void setTarget(AuthAddressValidator *);
+
+   virtual unsigned int topBlock() const = 0;
+   virtual void pushZC(const BinaryData &) = 0;
+   virtual std::string registerAddresses(const std::vector<bs::Address> &) = 0;
+
+   using OutpointsCb = std::function<void(OutpointBatch)>;
+   virtual void getOutpointsForAddresses(const std::vector<bs::Address> &
+      , const OutpointsCb &, unsigned int topBlock = 0, unsigned int zcIndex = 0) = 0;
+
+   using UTXOsCb = std::function<void(const std::vector<UTXO> &)>;
+   virtual void getSpendableTxOuts(const UTXOsCb &) = 0;
+   virtual void getUTXOsForAddress(const bs::Address &, const UTXOsCb &
+      , bool withZC = false) = 0;
+
+   using OnUpdate = std::function<void()>;
+   OnUpdate onUpdate{ nullptr };
+
+   using OnRefresh = std::function<void(const std::vector<BinaryData> &)>;
+   OnRefresh onRefresh{ nullptr };
+};
+
+class AuthAddressValidator
 {  /***
    This class tracks the state of validation addresses, which is
    required to check on the state of a user auth address.
@@ -209,73 +240,42 @@ class ValidationAddressManager
    features in unit tests.
    ***/
 
-private:
-   std::shared_ptr<ArmoryConnection> connPtr_;
-   std::shared_ptr<ValidationAddressACT> actPtr_;
-   std::shared_ptr<AsyncClient::BtcWallet> walletObj_;
-   ArmoryThreading::BlockingQueue<BinaryData> refreshQueue_;
-
-   std::map<BinaryData, std::shared_ptr<ValidationAddressStruct>> validationAddresses_;
-   unsigned topBlock_ = 0;
-   unsigned zcIndex_ = 0;
-
-   std::atomic<bool> ready_;
-   mutable std::mutex vettingMutex_;
-
-private:
-   std::shared_ptr<ValidationAddressStruct>
-      getValidationAddress(const BinaryData&);
-
-   UTXO getVettingUtxo(const bs::Address &validationAddr
-      , const std::vector<UTXO> &, size_t nbOutputs = 1) const;
-   std::vector<UTXO> filterVettingUtxos(const bs::Address &validationAddr
-      , const std::vector<UTXO> &) const;
-
-   const std::shared_ptr<ValidationAddressStruct>
-      getValidationAddress(const BinaryData&) const;
-
-   void waitOnRefresh(const std::string&);
-
 public:
-   ValidationAddressManager(std::shared_ptr<ArmoryConnection>);
-   ~ValidationAddressManager(void)
-   {  //unregister wallet
-      //shutdown act
-      if (actPtr_ != nullptr) {
-         actPtr_->stop();
+   AuthAddressValidator(const std::shared_ptr<AuthValidatorCallbacks> &callbacks)
+      : lambdas_(callbacks)
+   {}
+   virtual ~AuthAddressValidator(void)
+   {
+      if (lambdas_) {
+         lambdas_->shutdown();
       }
    }
 
    void addValidationAddress(const bs::Address &);
 
-   void setCustomACT(const std::shared_ptr<ValidationAddressACT> &);
-
    /*
    These methods return the amount of outpoints received. It
    allows for coverage of the db data flow.
    */
-   unsigned goOnline(void);
+   using ResultCb = std::function<void(bool)>;
+   bool goOnline(const ResultCb &);
+
    unsigned update(void);
+   void update(const ResultCb &);
 
    bool isReady() const { return ready_; }
 
    //utility methods
-   std::shared_ptr<ArmoryConnection> connPtr(void) const { return connPtr_; }
-   void pushRefreshID(std::vector<BinaryData>&);
+   void pushRefreshID(const std::vector<BinaryData> &);
 
    //validation address logic
-   bool isValid(const bs::Address&) const;
-   bool isValid(const BinaryData&) const;
+   bool isValidMasterAddress(const bs::Address&) const;
 
    bool hasSpendableOutputs(const bs::Address&) const;
    bool hasZCOutputs(const bs::Address&) const;
 
-   bool getOutpointBatch(const bs::Address &, const std::function<void(const OutpointBatch &)> &) const;
-   bool getSpendableTxOutFor(const bs::Address &, const std::function<void(const UTXO &)> &, size_t nbOutputs = 1) const;
-   bool getVettingUTXOsFor(const bs::Address &, const std::function<void(const std::vector<UTXO> &)> &) const;
-
-   const BinaryData& findValidationAddressForUTXO(const UTXO&) const;
-   const BinaryData& findValidationAddressForTxHash(const BinaryData&) const;
+   const bs::Address &findValidationAddressForUTXO(const UTXO&) const;
+   const bs::Address &findValidationAddressForTxHash(const BinaryData&) const;
 
    //tx generating methods
    BinaryData fundUserAddress(const bs::Address&, std::shared_ptr<ResolverFeed>,
@@ -291,24 +291,98 @@ public:
    BinaryData revokeUserAddress(
       const bs::Address&, std::shared_ptr<ResolverFeed>);
 
-   std::vector<UTXO> filterAuthFundingUTXO(const std::vector<UTXO>& authInputs);
+   std::vector<UTXO> filterVettingUtxos(const bs::Address &validationAddr
+      , const std::vector<UTXO> &) const;
+
+   unsigned int topBlock() const;
+   OutpointBatch getOutpointsFor(const bs::Address &) const;
+   std::vector<UTXO> getUTXOsFor(const bs::Address &, bool withZC = false) const;
+   void pushZC(const BinaryData &tx) const;
+
+protected:
+   virtual void prepareCallbacks() {}
+
+protected:
+   std::shared_ptr<AuthValidatorCallbacks>   lambdas_;
+
+private:
+   std::shared_ptr<ValidationAddressStruct>
+      getValidationAddress(const bs::Address &) const;
+
+   UTXO getVettingUtxo(const bs::Address &validationAddr
+      , const std::vector<UTXO> &, size_t nbOutputs = 1) const;
+
+   void waitOnRefresh(const std::string&);
+
+   OutpointBatch getOutpointsForAddresses(const std::vector<bs::Address> &
+      , unsigned int topBlock = 0, unsigned int zcIndex = 0) const;
+   std::vector<UTXO> getSpendableTxOuts() const;
+   std::vector<UTXO> getUTXOsForAddress(const bs::Address &
+      , bool withZC = false) const;
+
+private:
+   ArmoryThreading::BlockingQueue<BinaryData> refreshQueue_;
+
+   std::map<bs::Address, std::shared_ptr<ValidationAddressStruct>>   validationAddresses_;
+   unsigned topBlock_ = 0;
+   unsigned zcIndex_ = 0;
+
+   std::atomic_bool  ready_{ false };
+   mutable std::mutex vettingMutex_;
+   std::mutex updateMutex_;
+};
+
+////
+class ValidationAddressManager : public AuthAddressValidator
+{  /***
+   This class tracks the state of validation addresses, which is
+   required to check on the state of a user auth address.
+
+   It uses a blocking model for the purpose of demonstrating the
+   features in unit tests.
+   ***/
+
+public:
+   ValidationAddressManager(const std::shared_ptr<ArmoryConnection> &);
+   virtual ~ValidationAddressManager();
+
+   void setCustomACT(const std::shared_ptr<ValidationAddressACT> &);
+
+protected:
+   void prepareCallbacks() override;
+
+private:
+   std::shared_ptr<ValidationAddressACT> actPtr_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-struct AuthAddressLogic
+namespace AuthAddressLogic
 {
-   static AddressVerificationState getAuthAddrState(const ValidationAddressManager &
+   struct AddrPathsStatus
+   {
+      /*
+      Paths are signified by the order of outputs on the address
+      */
+      unsigned pathCount_ = UINT32_MAX;
+      std::map<unsigned, OutpointData> validPaths_;
+      std::vector<unsigned> invalidPaths_;
+      std::vector<unsigned> revokedPaths_;
+
+      bool isInitialized(void) const;
+      bool isValid(void) const;
+      const OutpointData& getValidationOutpoint(void) const;
+   };
+
+   AddressVerificationState getAuthAddrState(const AuthAddressValidator &
       , const bs::Address &);
-   static bool isValid(const ValidationAddressManager &vam, const bs::Address &addr) {
-      return (getAuthAddrState(vam, addr) == AddressVerificationState::Verified);
-   }
-   static std::vector<OutpointData> getValidPaths(
-      const ValidationAddressManager&, const bs::Address&, size_t &nbPaths);
-   static BinaryData revoke(const ValidationAddressManager&, const bs::Address&,
-      std::shared_ptr<ResolverFeed>);
-   static std::pair<bs::Address, UTXO> getRevokeData(const ValidationAddressManager &
+   bool isValid(const AuthAddressValidator &, const bs::Address &);
+   AddrPathsStatus getAddrPathsStatus(const AuthAddressValidator &
+      , const bs::Address &);
+   BinaryData revoke(const AuthAddressValidator &, const bs::Address &
+      , const std::shared_ptr<ResolverFeed> &);
+   std::pair<bs::Address, UTXO> getRevokeData(const AuthAddressValidator &
       , const bs::Address &authAddr);
-   static BinaryData revoke(const bs::Address &, const std::shared_ptr<ResolverFeed> &
+   BinaryData revoke(const bs::Address &, const std::shared_ptr<ResolverFeed> &
       , const bs::Address &validationAddr, const UTXO &);
 };
 

--- a/BlocksettleNetworkingLib/AuthAddressManager.cpp
+++ b/BlocksettleNetworkingLib/AuthAddressManager.cpp
@@ -57,9 +57,16 @@ void AuthAddressManager::init(const std::shared_ptr<ApplicationSettings>& appSet
    ArmoryCallbackTarget::init(armory_.get());
 }
 
-void AuthAddressManager::setCelerClient(const std::shared_ptr<BaseCelerClient>& celerClient)
+void AuthAddressManager::initLogin(const std::shared_ptr<BaseCelerClient> &celerClient
+   , const std::shared_ptr<bs::TradeSettings> &tradeSettings)
 {
    celerClient_ = celerClient;
+   tradeSettings_ = tradeSettings;
+}
+
+const std::shared_ptr<bs::TradeSettings>& AuthAddressManager::tradeSettings() const
+{
+   return tradeSettings_;
 }
 
 void AuthAddressManager::SetAuthWallet()
@@ -90,8 +97,19 @@ bool AuthAddressManager::setup()
          return;
       }
       if (GetState(address) != state) {
-         logger_->info("Address verification {} for {}", to_string(state), address.display());
-         SetState(address, state);
+         logger_->info("Address verification on chain {} for {}", to_string(state), address.display());
+
+         if (state == AddressVerificationState::VerificationFailed) {
+            const auto &submittedAddresses = celerClient_->GetSubmittedAuthAddressSet();
+            if (submittedAddresses.find(address.display()) != submittedAddresses.end()) {
+               SetState(address, AddressVerificationState::VerificationFailed);
+            } else {
+               SetState(address, state);
+            }
+         } else {
+            SetState(address, state);
+         }
+
          emit AddressListUpdated();
          if (state == AddressVerificationState::Verified) {
             emit VerifiedAddressListUpdated();
@@ -166,45 +184,6 @@ bool AuthAddressManager::HasAuthAddr() const
    return (HaveAuthWallet() && (authWallet_->getUsedAddressCount() > 0));
 }
 
-void AuthAddressManager::SubmitForVerification(const std::weak_ptr<BsClient> &bsClient, const bs::Address &address)
-{
-   auto bsClientPtr = bsClient.lock();
-   if (!bsClientPtr) {
-      return;
-   }
-
-   if (!hasSettlementLeaf(address)) {
-      SPDLOG_LOGGER_ERROR(logger_, "can't submit without existing settlement leaf");
-      emit Error(tr("Settlement leaf does not exist"));
-      return;
-   }
-   const auto state = GetState(address);
-   if (state != AddressVerificationState::NotSubmitted) {
-      SPDLOG_LOGGER_ERROR(logger_, "refuse to submit address in state: {}", (int)state);
-      emit Error(tr("Address must be not submitted"));
-      return;
-   }
-
-   bsClientPtr->submitAuthAddress(address, [this, address](const BsClient::AuthAddrSubmitResponse &response) {
-      if (!response.success) {
-         SPDLOG_LOGGER_ERROR(logger_, "auth address {} rejected, errorMsg: '{}'"
-            , address.display(), response.errorMsg);
-         if (response.errorMsg.empty()) {
-            emit Error(tr("Authentication Address rejected"));
-         } else {
-            emit Error(tr("Authentication Address rejected: %1").arg(QString::fromStdString(response.errorMsg)));
-         }
-         return;
-      }
-
-      if (response.confirmationRequired) {
-         emit AuthAddressConfirmationRequired(response.validationAmountCents / 100.0f);
-      } else {
-         markAsSubmitted(address);
-      }
-   });
-}
-
 bool AuthAddressManager::CreateNewAuthAddress()
 {
    const auto &cbAddr = [this](const bs::Address &) {
@@ -240,7 +219,7 @@ void AuthAddressManager::onTXSigned(unsigned int id, BinaryData signedTX, bs::er
 bool AuthAddressManager::RevokeAddress(const bs::Address &address)
 {
    const auto state = GetState(address);
-   if ((state != AddressVerificationState::PendingVerification) && (state != AddressVerificationState::Verified)) {
+   if ((state != AddressVerificationState::Verifying) && (state != AddressVerificationState::Verified)) {
       logger_->warn("[AuthAddressManager::RevokeAddress] attempting to revoke from incorrect state {}", (int)state);
       emit Error(tr("incorrect state"));
       return false;
@@ -322,7 +301,7 @@ void AuthAddressManager::ConfirmSubmitForVerification(const std::weak_ptr<BsClie
 
       if (!response.success) {
          SPDLOG_LOGGER_ERROR(logger_, "signing auth address failed: {}", response.errorMsg);
-         emit AuthConfirmSubmitError(QString::fromStdString(address.display()), QString::fromStdString(response.errorMsg));
+         emit AuthAddressSubmitError(QString::fromStdString(address.display()), QString::fromStdString(response.errorMsg));
          return;
       }
 
@@ -337,7 +316,7 @@ void AuthAddressManager::ConfirmSubmitForVerification(const std::weak_ptr<BsClie
       bsClientPtr->confirmAuthAddress(address, [this, address] (const BsClient::BasicResponse &response) {
          if (!response.success) {
             SPDLOG_LOGGER_ERROR(logger_, "confirming auth address failed: {}", response.errorMsg);
-            emit AuthConfirmSubmitError(QString::fromStdString(address.display()), QString::fromStdString(response.errorMsg));
+            emit AuthAddressSubmitError(QString::fromStdString(address.display()), QString::fromStdString(response.errorMsg));
             return;
          }
 
@@ -387,15 +366,10 @@ void AuthAddressManager::VerifyWalletAddressesFunction()
    }
    bool updated = false;
 
-   const auto &submittedAddresses = celerClient_->GetSubmittedAuthAddressSet();
-
    if (!WalletAddressesLoaded()) {
       if (authWallet_ != nullptr) {
          for (const auto &addr : authWallet_->getUsedAddressList()) {
             AddAddress(addr);
-            if (submittedAddresses.find(addr.display()) != submittedAddresses.end()) {
-               SetState(addr, AddressVerificationState::Submitted);
-            }
          }
       }
       else {
@@ -468,7 +442,7 @@ void AuthAddressManager::onWalletChanged(const std::string &walletId)
 
 void AuthAddressManager::AddAddress(const bs::Address &addr)
 {
-   SetState(addr, AddressVerificationState::InProgress);
+   SetState(addr, AddressVerificationState::VerificationFailed);
    FastLock locker(lockList_);
    addresses_.emplace_back(addr);
 }
@@ -537,7 +511,7 @@ AddressVerificationState AuthAddressManager::GetState(const bs::Address &addr) c
    FastLock lock(statesLock_);
    const auto itState = states_.find(addr);
    if (itState == states_.end()) {
-      return AddressVerificationState::InProgress;
+      return AddressVerificationState::VerificationFailed;
    }
    return itState->second;
 }
@@ -545,7 +519,7 @@ AddressVerificationState AuthAddressManager::GetState(const bs::Address &addr) c
 void AuthAddressManager::SetState(const bs::Address &addr, AddressVerificationState state)
 {
    const auto prevState = GetState(addr);
-   if ((prevState == AddressVerificationState::Submitted) && (state == AddressVerificationState::NotSubmitted)) {
+   if (prevState == AddressVerificationState::Verifying) {
       return;
    }
 
@@ -554,11 +528,13 @@ void AuthAddressManager::SetState(const bs::Address &addr, AddressVerificationSt
       states_[addr] = state;
    }
 
-   if ((state == AddressVerificationState::Verified) && (prevState == AddressVerificationState::PendingVerification)) {
+   if ((state == AddressVerificationState::Verified) && (prevState == AddressVerificationState::Verifying)) {
       emit AddrVerifiedOrRevoked(QString::fromStdString(addr.display()), tr("Verified"));
    }
-   else if (((state == AddressVerificationState::Revoked) || (state == AddressVerificationState::RevokedByBS))
-      && (prevState == AddressVerificationState::Verified)) {
+   else if ((state == AddressVerificationState::Revoked) || 
+            (state == AddressVerificationState::Invalidated_Explicit) ||
+            (state == AddressVerificationState::Invalidated_Implicit) &&
+            (prevState == AddressVerificationState::Verified)) {
       emit AddrVerifiedOrRevoked(QString::fromStdString(addr.display()), tr("Revoked"));
    }
 
@@ -584,7 +560,11 @@ bs::Address AuthAddressManager::getDefault() const
       if (!defaultAuthAddrStr.empty()) {
          defaultAddr_ = bs::Address::fromAddressString(defaultAuthAddrStr);
       }
-      const auto &verifAddresses = GetVerifiedAddressList();
+      auto verifAddresses = GetVerifiedAddressList();
+      if (verifAddresses.empty()) {
+         verifAddresses = GetSubmittedAddressList();
+      }
+
       if (verifAddresses.empty()) {
          defaultAddr_.clear();
          return {};
@@ -616,6 +596,26 @@ size_t AuthAddressManager::getDefaultIndex() const
    return 0;
 }
 
+std::vector<bs::Address> AuthAddressManager::GetSubmittedAddressList(bool includeVerified /* = true */) const
+{
+   std::vector<bs::Address> list;
+   {
+      list.reserve(addresses_.size());
+
+      FastLock locker(lockList_);
+      for (const auto& address : addresses_) {
+         const auto addressState = GetState(address);
+
+         if (   addressState == AddressVerificationState::Verifying
+             || (includeVerified && addressState == AddressVerificationState::Verified))
+         {
+            list.emplace_back(address);
+         }
+      }
+   }
+   return list;
+}
+
 std::vector<bs::Address> AuthAddressManager::GetVerifiedAddressList() const
 {
    std::vector<bs::Address> list;
@@ -636,9 +636,8 @@ bool AuthAddressManager::isAtLeastOneAwaitingVerification() const
       FastLock locker(lockList_);
       for (const auto &address : addresses_) {
          auto addrState = GetState(address);
-         if (addrState == AddressVerificationState::Submitted
-            || addrState == AddressVerificationState::PendingVerification
-            || addrState == AddressVerificationState::VerificationSubmitted) {
+         if (addrState == AddressVerificationState::Verifying
+            || addrState == AddressVerificationState::Verified) {
             return true;
          }
       }
@@ -652,28 +651,12 @@ bool AuthAddressManager::isAllLoadded() const
       FastLock locker(lockList_);
       for (const auto &address : addresses_) {
          auto addrState = GetState(address);
-         if (addrState == AddressVerificationState::InProgress) {
+         if (addrState == AddressVerificationState::VerificationFailed) {
             return false;
          }
       }
    }
    return true;
-}
-
-size_t AuthAddressManager::FromVerifiedIndex(size_t index) const
-{
-   if (index < addresses_.size()) {
-      size_t nbVerified = 0;
-      for (size_t i = 0; i < addresses_.size(); i++) {
-         if (GetState(addresses_[i]) == AddressVerificationState::Verified) {
-            if (nbVerified == index) {
-               return i;
-            }
-            nbVerified++;
-         }
-      }
-   }
-   return UINT32_MAX;
 }
 
 void AuthAddressManager::SetBSAddressList(const std::unordered_set<std::string>& bsAddressList)
@@ -703,9 +686,9 @@ void AuthAddressManager::onStateChanged(ArmoryState)
 void AuthAddressManager::markAsSubmitted(const bs::Address &address)
 {
    SubmitToCeler(address);
-   SetState(address, AddressVerificationState::Submitted);
+   SetState(address, AddressVerificationState::VerificationFailed);
    emit AddressListUpdated();
-   emit AuthAddrSubmitSuccess(QString::fromStdString(address.display()));
+   emit AuthAddressSubmitSuccess(QString::fromStdString(address.display()));
 }
 
 template <typename TVal> TVal AuthAddressManager::lookup(const bs::Address &key, const std::map<bs::Address, TVal> &container) const

--- a/BlocksettleNetworkingLib/AuthAddressManager.h
+++ b/BlocksettleNetworkingLib/AuthAddressManager.h
@@ -42,6 +42,7 @@ namespace bs {
       class Wallet;
       class WalletsManager;
    }
+   struct TradeSettings;
 }
 class AddressVerificator;
 class ApplicationSettings;
@@ -79,40 +80,42 @@ public:
    void init(const std::shared_ptr<ApplicationSettings> &
       , const std::shared_ptr<bs::sync::WalletsManager> &
       , const std::shared_ptr<SignContainer> &);
-   void setCelerClient(const std::shared_ptr<BaseCelerClient> &);
+   void initLogin(const std::shared_ptr<BaseCelerClient> &,
+      const std::shared_ptr<bs::TradeSettings> &);
+
+   const std::shared_ptr<bs::TradeSettings>& tradeSettings() const;
 
    size_t GetAddressCount();
    bs::Address GetAddress(size_t index);
 
    AddressVerificationState GetState(const bs::Address &addr) const;
-   void SetState(const bs::Address &addr, AddressVerificationState state);
 
    void setDefault(const bs::Address &addr);
-   bs::Address getDefault() const;
-   virtual size_t getDefaultIndex() const;
 
-   virtual bool HaveAuthWallet() const;
-   virtual bool HasAuthAddr() const;
+   bs::Address getDefault() const;
+   size_t getDefaultIndex() const;
+
+   bool HaveAuthWallet() const;
+   bool HasAuthAddr() const;
 
    void createAuthWallet(const std::function<void()> &);
-   virtual bool CreateNewAuthAddress();
+   bool CreateNewAuthAddress();
 
    bool hasSettlementLeaf(const bs::Address &) const;
    void createSettlementLeaf(const bs::Address &, const std::function<void()> &);
 
-   virtual void SubmitForVerification(const std::weak_ptr<BsClient> &bsClient, const bs::Address &address);
-   virtual void ConfirmSubmitForVerification(const std::weak_ptr<BsClient> &bsClient, const bs::Address &address);
+   void ConfirmSubmitForVerification(const std::weak_ptr<BsClient> &bsClient, const bs::Address &address);
 
-   virtual bool RevokeAddress(const bs::Address &address);
+   bool RevokeAddress(const bs::Address &address);
 
-   virtual ReadyError readyError() const;
+   ReadyError readyError() const;
 
-   virtual void OnDisconnectedFromCeler();
+   void OnDisconnectedFromCeler();
 
-   virtual std::vector<bs::Address> GetVerifiedAddressList() const;
+   std::vector<bs::Address> GetSubmittedAddressList(bool includeVerified = true) const;
+
    bool isAtLeastOneAwaitingVerification() const;
    bool isAllLoadded() const;
-   size_t FromVerifiedIndex(size_t index) const;
    const std::unordered_set<std::string> &GetBSAddresses() const;
 
    void setAuthAddressesSigned(const BinaryData &data);
@@ -137,13 +140,12 @@ signals:
    void ConnectionComplete();
    void Error(const QString &errorText) const;
    void Info(const QString &info);
-   void AuthAddrSubmitError(const QString &address, const QString &error);
-   void AuthConfirmSubmitError(const QString &address, const QString &error);
-   void AuthAddrSubmitSuccess(const QString &address);
+
+   void AuthAddressSubmitError(const QString &address, const QString &error);
+   void AuthAddressSubmitSuccess(const QString &address);
    void AuthAddressSubmitCancelled(const QString &address);
    void AuthRevokeTxSent();
    void gotBsAddressList();
-   void AuthAddressConfirmationRequired(float validationAmount);
 
 private:
    void SetAuthWallet();
@@ -170,6 +172,10 @@ private:
 
    void markAsSubmitted(const bs::Address &address);
 
+   std::vector<bs::Address> GetVerifiedAddressList() const;
+
+   void SetState(const bs::Address &addr, AddressVerificationState state);
+
 protected:
    std::shared_ptr<spdlog::logger>        logger_;
    std::shared_ptr<ArmoryConnection>      armory_;
@@ -192,6 +198,7 @@ protected:
 
    std::shared_ptr<SignContainer>      signingContainer_;
    std::unordered_set<unsigned int>    signIdsRevoke_;
+   std::shared_ptr<bs::TradeSettings>  tradeSettings_;
 
 };
 

--- a/BlocksettleNetworkingLib/BIP15xHelpers.cpp
+++ b/BlocksettleNetworkingLib/BIP15xHelpers.cpp
@@ -64,7 +64,7 @@ bool bip15x::isValidPubKey(const BinaryData &pubKey)
 bool bip15x::addAuthPeer(AuthorizedPeers *authPeers, const BIP15xPeer &peer)
 {
    authPeers->eraseName(peer.name());
-   authPeers->addPeer(peer.pubKey(), peer.name());
+   authPeers->addPeer(peer.pubKey(), std::vector<std::string>{peer.name()});
    return true;
 }
 

--- a/BlocksettleNetworkingLib/BIP15xMessage.h
+++ b/BlocksettleNetworkingLib/BIP15xMessage.h
@@ -51,8 +51,6 @@ namespace bs {
             AuthChallenge = 21,
             AuthReply = 22,
             AuthPropose = 23,
-            Heartbeat = 30,
-            Disconnect = 31
          };
 
          constexpr unsigned int AEAD_REKEY_INTERVAL_SECS = 600;
@@ -77,7 +75,6 @@ namespace bs {
 
             // Returns packet that is ready for send
             BinaryData build() const;
-            static std::vector<BinaryData> parsePackets(const BinaryDataRef& packets);
 
          private:
             void construct(const uint8_t *data, uint32_t dataSize, MsgType type);

--- a/BlocksettleNetworkingLib/BSMarketDataProvider.h
+++ b/BlocksettleNetworkingLib/BSMarketDataProvider.h
@@ -32,7 +32,8 @@ class BSMarketDataProvider : public MarketDataProvider
 {
 public:
    BSMarketDataProvider(const std::shared_ptr<ConnectionManager>& connectionManager
-      , const std::shared_ptr<spdlog::logger> &, MDCallbackTarget *);
+      , const std::shared_ptr<spdlog::logger> &, MDCallbackTarget *
+      , bool acceptUsdPairs = false);
    ~BSMarketDataProvider() noexcept override = default;
 
    BSMarketDataProvider(const BSMarketDataProvider&) = delete;
@@ -73,6 +74,8 @@ private:
    std::shared_ptr<ConnectionManager>  connectionManager_;
    std::shared_ptr<SubscriberConnection> mdConnection_ = nullptr;
    std::shared_ptr<SubscriberConnectionListenerCB> listener_ = nullptr;
+
+   bool acceptUsdPairs_;
 };
 
 #endif // __BS_MARKET_DATA_PROVIDER_H__

--- a/BlocksettleNetworkingLib/Bip15xDataConnection.cpp
+++ b/BlocksettleNetworkingLib/Bip15xDataConnection.cpp
@@ -46,11 +46,12 @@ public:
 
 Bip15xDataConnection::Bip15xDataConnection(const std::shared_ptr<spdlog::logger> &logger
    , std::unique_ptr<DataConnection> conn
-   , std::shared_ptr<bs::network::TransportClient> tr)
+   , const std::shared_ptr<bs::network::TransportClient> &tr)
    : logger_(logger)
-   , transport_(std::move(tr))
+   , transport_(tr)
    , conn_(std::move(conn))
 {
+   assert(conn_);
    transport_->setSendCb([this](const std::string &d) {
       return conn_->send(d);
    });
@@ -87,7 +88,7 @@ bool Bip15xDataConnection::openConnection(const std::string &host, const std::st
 bool Bip15xDataConnection::closeConnection()
 {
    bool result = conn_->closeConnection();
-   transport_.reset();
+   transport_->closeConnection();
    return result;
 }
 

--- a/BlocksettleNetworkingLib/Bip15xDataConnection.cpp
+++ b/BlocksettleNetworkingLib/Bip15xDataConnection.cpp
@@ -1,0 +1,97 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#include "Bip15xDataConnection.h"
+
+#include <spdlog/spdlog.h>
+#include "Transport.h"
+
+class Bip15xDataListener : public DataConnectionListener
+{
+public:
+   Bip15xDataConnection *owner_{};
+
+   void OnDataReceived(const std::string& data) override
+   {
+      owner_->transport_->onRawDataReceived(data);
+   }
+
+   void OnConnected() override
+   {
+      owner_->transport_->startHandshake();
+   }
+
+   void OnDisconnected() override
+   {
+      if (owner_->connected_) {
+         owner_->connected_ = false;
+         owner_->listener_->OnDisconnected();
+      }
+   }
+
+   void OnError(DataConnectionError errorCode) override
+   {
+      OnDisconnected();
+      owner_->listener_->OnError(errorCode);
+   }
+};
+
+
+Bip15xDataConnection::Bip15xDataConnection(const std::shared_ptr<spdlog::logger> &logger
+   , std::unique_ptr<DataConnection> conn
+   , std::shared_ptr<bs::network::TransportClient> tr)
+   : logger_(logger)
+   , transport_(std::move(tr))
+   , conn_(std::move(conn))
+{
+   transport_->setSendCb([this](const std::string &d) {
+      return conn_->send(d);
+   });
+
+   transport_->setNotifyDataCb([this](const std::string &d) {
+      listener_->OnDataReceived(d);
+   });
+
+   transport_->setSocketErrorCb([this](DataConnectionListener::DataConnectionError e) {
+      if (e == DataConnectionListener::NoError) {
+         connected_ = true;
+         listener_->OnConnected();
+         return;
+      }
+      listener_->OnError(e);
+   });
+}
+
+Bip15xDataConnection::~Bip15xDataConnection()
+{
+   closeConnection();
+}
+
+bool Bip15xDataConnection::openConnection(const std::string &host, const std::string &port
+   , DataConnectionListener *listener)
+{
+   listener_ = listener;
+   ownListener_ = std::make_unique<Bip15xDataListener>();
+   ownListener_->owner_ = this;
+   transport_->openConnection(host, port);
+   return conn_->openConnection(host, port, ownListener_.get());
+}
+
+bool Bip15xDataConnection::closeConnection()
+{
+   bool result = conn_->closeConnection();
+   transport_.reset();
+   return result;
+}
+
+bool Bip15xDataConnection::send(const std::string &data)
+{
+   return transport_->sendData(data);
+}

--- a/BlocksettleNetworkingLib/Bip15xDataConnection.h
+++ b/BlocksettleNetworkingLib/Bip15xDataConnection.h
@@ -32,7 +32,7 @@ class Bip15xDataConnection : public DataConnection
 public:
    Bip15xDataConnection(const std::shared_ptr<spdlog::logger> &
       , std::unique_ptr<DataConnection> conn
-      , std::shared_ptr<bs::network::TransportClient>);
+      , const std::shared_ptr<bs::network::TransportClient> &);
    ~Bip15xDataConnection() override;
 
    Bip15xDataConnection(const Bip15xDataConnection&) = delete;

--- a/BlocksettleNetworkingLib/Bip15xDataConnection.h
+++ b/BlocksettleNetworkingLib/Bip15xDataConnection.h
@@ -1,0 +1,61 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#ifndef BIP15X_DATA_CONNECTION_H
+#define BIP15X_DATA_CONNECTION_H
+
+#include "DataConnection.h"
+
+#include <memory>
+#include <atomic>
+
+namespace spdlog {
+   class logger;
+}
+namespace bs {
+   namespace network {
+      class TransportClient;
+   }
+}
+
+class Bip15xDataListener;
+
+class Bip15xDataConnection : public DataConnection
+{
+public:
+   Bip15xDataConnection(const std::shared_ptr<spdlog::logger> &
+      , std::unique_ptr<DataConnection> conn
+      , std::shared_ptr<bs::network::TransportClient>);
+   ~Bip15xDataConnection() override;
+
+   Bip15xDataConnection(const Bip15xDataConnection&) = delete;
+   Bip15xDataConnection& operator = (const Bip15xDataConnection&) = delete;
+   Bip15xDataConnection(Bip15xDataConnection&&) = delete;
+   Bip15xDataConnection& operator = (Bip15xDataConnection&&) = delete;
+
+   bool openConnection(const std::string& host, const std::string& port
+      , DataConnectionListener* listener) override;
+   bool closeConnection() override;
+
+   bool send(const std::string& data) override;
+   bool isActive() const override { return conn_->isActive(); }
+
+private:
+   friend class Bip15xDataListener;
+
+   std::shared_ptr<spdlog::logger> logger_;
+   std::shared_ptr<bs::network::TransportClient> transport_;
+   std::unique_ptr<DataConnection> conn_;
+   std::unique_ptr<Bip15xDataListener> ownListener_;
+   std::atomic_bool connected_{};
+};
+
+
+#endif // BIP15X_DATA_CONNECTION_H

--- a/BlocksettleNetworkingLib/Bip15xServerConnection.cpp
+++ b/BlocksettleNetworkingLib/Bip15xServerConnection.cpp
@@ -1,0 +1,125 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#include "Bip15xServerConnection.h"
+
+#include "StringUtils.h"
+#include "ThreadName.h"
+#include "Transport.h"
+#include "WsConnection.h"
+
+#include <spdlog/spdlog.h>
+
+class Bip15xServerListener : public ServerConnectionListener
+{
+public:
+   Bip15xServerConnection *owner_{};
+
+   void OnDataFromClient(const std::string& clientId, const std::string& data) override
+   {
+      owner_->transport_->processIncomingData(data, clientId);
+   }
+
+   void OnClientConnected(const std::string& clientId, const Details &details) override
+   {
+      owner_->transport_->addClient(clientId, details);
+   }
+
+   void OnClientDisconnected(const std::string& clientId) override
+   {
+      bool wasConnected;
+      { std::lock_guard<std::mutex> lock(owner_->mutex_);
+         wasConnected = owner_->clients_.erase(clientId) == 1;
+      }
+      if (wasConnected) {
+         owner_->listener_->OnClientDisconnected(clientId);
+      }
+      owner_->transport_->closeClient(clientId);
+   }
+
+   void onClientError(const std::string &clientId, ClientError error
+      , const ServerConnectionListener::Details &details) override
+   {
+      OnClientDisconnected(clientId);
+      owner_->listener_->onClientError(clientId, error, details);
+   }
+};
+
+
+Bip15xServerConnection::Bip15xServerConnection(const std::shared_ptr<spdlog::logger>& logger
+   , std::unique_ptr<ServerConnection> server
+   , const std::shared_ptr<bs::network::TransportServer> &tr)
+   : logger_(logger)
+   , server_(std::move(server))
+   , transport_(tr)
+{
+   transport_->setClientErrorCb([this](const std::string &id
+      , ServerConnectionListener::ClientError err
+      , const ServerConnectionListener::Details &details) {
+      listener_->onClientError(id, err, details);
+   });
+
+   transport_->setDataReceivedCb([this](const std::string &clientId, const std::string &data) {
+      listener_->OnDataFromClient(clientId, data);
+   });
+
+   transport_->setSendDataCb([this](const std::string &clientId, const std::string &data) {
+      return server_->SendDataToClient(clientId, data);
+   });
+
+   transport_->setConnectedCb([this](const std::string &clientId, const ServerConnectionListener::Details &details) {
+      {  std::lock_guard<std::mutex> lock(mutex_);
+         clients_.insert(clientId);
+      }
+      listener_->OnClientConnected(clientId, details);
+   });
+
+   transport_->setDisconnectedCb([this](const std::string &clientId) {
+      bool wasConnected;
+      { std::lock_guard<std::mutex> lock(mutex_);
+         wasConnected = clients_.erase(clientId) == 1;
+      }
+      if (wasConnected) {
+         listener_->OnClientDisconnected(clientId);
+      }
+   });
+}
+
+Bip15xServerConnection::~Bip15xServerConnection()
+{
+   server_.reset();
+}
+
+bool Bip15xServerConnection::BindConnection(const std::string& host , const std::string& port
+   , ServerConnectionListener* listener)
+{
+   ownListener_ = std::make_unique<Bip15xServerListener>();
+   ownListener_->owner_ = this;
+   bool result = server_->BindConnection(host, port, ownListener_.get());
+   listener_ = listener;
+   return result;
+}
+
+bool Bip15xServerConnection::SendDataToClient(const std::string &clientId, const std::string &data)
+{
+   return transport_->sendData(clientId, data);
+}
+
+bool Bip15xServerConnection::SendDataToAllClients(const std::string &data)
+{
+   std::lock_guard<std::mutex> lock(mutex_);
+   size_t cntClients = clients_.size();
+   for (const auto &item : clients_) {
+      if (SendDataToClient(item, data)) {
+         cntClients--;
+      }
+   }
+   return (cntClients == 0);
+}

--- a/BlocksettleNetworkingLib/Bip15xServerConnection.cpp
+++ b/BlocksettleNetworkingLib/Bip15xServerConnection.cpp
@@ -75,7 +75,8 @@ Bip15xServerConnection::Bip15xServerConnection(const std::shared_ptr<spdlog::log
    });
 
    transport_->setConnectedCb([this](const std::string &clientId, const ServerConnectionListener::Details &details) {
-      {  std::lock_guard<std::mutex> lock(mutex_);
+      {
+         std::lock_guard<std::mutex> lock(mutex_);
          clients_.insert(clientId);
       }
       listener_->OnClientConnected(clientId, details);

--- a/BlocksettleNetworkingLib/Bip15xServerConnection.h
+++ b/BlocksettleNetworkingLib/Bip15xServerConnection.h
@@ -1,0 +1,64 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#ifndef BIP15X_SERVER_CONNECTION_H
+#define BIP15X_SERVER_CONNECTION_H
+
+#include "ServerConnection.h"
+
+#include <memory>
+#include <mutex>
+#include <set>
+
+namespace spdlog {
+   class logger;
+}
+namespace bs{
+   namespace network {
+      class TransportServer;
+   }
+}
+
+class Bip15xServerListener;
+
+class Bip15xServerConnection : public ServerConnection
+{
+public:
+   Bip15xServerConnection(const std::shared_ptr<spdlog::logger> &
+      , std::unique_ptr<ServerConnection>
+      , const std::shared_ptr<bs::network::TransportServer> &);
+   ~Bip15xServerConnection() override;
+
+   Bip15xServerConnection(const Bip15xServerConnection&) = delete;
+   Bip15xServerConnection& operator = (const Bip15xServerConnection&) = delete;
+   Bip15xServerConnection(Bip15xServerConnection&&) = delete;
+   Bip15xServerConnection& operator = (Bip15xServerConnection&&) = delete;
+
+   bool BindConnection(const std::string& host, const std::string& port
+      , ServerConnectionListener* listener) override;
+
+   bool SendDataToClient(const std::string& clientId, const std::string& data) override;
+   bool SendDataToAllClients(const std::string&) override;
+
+private:
+   friend class Bip15xServerListener;
+
+   std::shared_ptr<spdlog::logger> logger_;
+   std::unique_ptr<ServerConnection> server_;
+   std::shared_ptr<bs::network::TransportServer> transport_;
+   std::unique_ptr<Bip15xServerListener> ownListener_;
+
+   ServerConnectionListener *listener_{};
+
+   std::mutex mutex_;
+   std::set<std::string> clients_;
+};
+
+#endif // BIP15X_SERVER_CONNECTION_H

--- a/BlocksettleNetworkingLib/ChatProtocol/ChatClientLogic.cpp
+++ b/BlocksettleNetworkingLib/ChatProtocol/ChatClientLogic.cpp
@@ -13,10 +13,11 @@
 
 #include "ChatProtocol/ChatClientLogic.h"
 
+#include "Bip15xDataConnection.h"
 #include "ConnectionManager.h"
 #include "DataConnection.h"
-#include "ZmqDataConnection.h"
 #include "ProtobufUtils.h"
+#include "WsDataConnection.h"
 
 #include <disable_warnings.h>
 #include <spdlog/spdlog.h>
@@ -130,8 +131,8 @@ void ChatClientLogic::LoginToServer(const BinaryData &token, const BinaryData &t
    params.ephemeralPeers = true;
    const auto &transport = std::make_shared<bs::network::TransportBIP15xClient>(loggerPtr_, params);
    transport->setKeyCb(cb);
-   auto conn =  std::make_unique<ZmqBinaryConnection>(loggerPtr_, transport);
-   conn->SetContext(std::make_shared<ZmqContext>(loggerPtr_));
+   auto wsConn = std::make_unique<WsDataConnection>(loggerPtr_, WsDataConnectionParams{});
+   auto conn = std::make_unique<Bip15xDataConnection>(loggerPtr_, std::move(wsConn), transport);
    connectionPtr_ = std::move(conn);
 
    clientConnectionLogicPtr_->setToken(token, tokenSign);

--- a/BlocksettleNetworkingLib/ColoredCoinServer.cpp
+++ b/BlocksettleNetworkingLib/ColoredCoinServer.cpp
@@ -457,7 +457,8 @@ void CcTrackerClient::reconnect()
    const auto &transport = std::make_shared<bs::network::TransportBIP15xClient>(logger_, params);
    transport->setKeyCb(newKeyCb_);
 
-   connection_ = std::make_unique<WsDataConnection>(logger_, transport);
+   WsDataConnectionParams wsParams;
+   connection_ = std::make_unique<WsDataConnection>(logger_, wsParams);
    bool result = connection_->openConnection(host_, port_, this);
    assert(result);
 }
@@ -584,7 +585,7 @@ void CcTrackerServer::OnDataFromClient(const std::string &clientId, const std::s
    });
 }
 
-void CcTrackerServer::OnClientConnected(const std::string &clientId)
+void CcTrackerServer::OnClientConnected(const std::string &clientId, const Details &details)
 {
    SPDLOG_LOGGER_INFO(logger_, "new client connected: {}", bs::toHex(clientId));
    dispatchQueue_.dispatch([this, clientId] {

--- a/BlocksettleNetworkingLib/ColoredCoinServer.h
+++ b/BlocksettleNetworkingLib/ColoredCoinServer.h
@@ -116,7 +116,7 @@ public:
 
    void OnDataFromClient(const std::string& clientId, const std::string& data) override;
 
-   void OnClientConnected(const std::string& clientId) override;
+   void OnClientConnected(const std::string& clientId, const Details &details) override;
    void OnClientDisconnected(const std::string& clientId) override;
 
 private:

--- a/BlocksettleNetworkingLib/ConnectionManager.cpp
+++ b/BlocksettleNetworkingLib/ConnectionManager.cpp
@@ -18,8 +18,6 @@
 #include "SubscriberConnection.h"
 #include "ZmqContext.h"
 #include "ZmqDataConnection.h"
-#include "TransportBIP15x.h"
-#include "TransportBIP15xServer.h"
 
 #include <QNetworkAccessManager>
 
@@ -113,37 +111,6 @@ std::shared_ptr<DataConnection> ConnectionManager::CreateGenoaClientConnection(b
    connection->SetContext(zmqContext_);
 
    return connection;
-}
-
-std::shared_ptr<ServerConnection> ConnectionManager::createZmqBIP15xChatServerConnection(
-   bool ephemeral, const std::string& ownKeyFileDir, const std::string& ownKeyFileName) const
-{
-   auto cbTrustedClients = [this]() {
-      return zmqTrustedTerminals_;
-   };
-   const auto &bip15xTransport = std::make_shared<bs::network::TransportBIP15xServer>(
-      logger_, cbTrustedClients, ephemeral, ownKeyFileDir, ownKeyFileName, false);
-
-   return std::make_shared<GenoaStreamServerConnection>(logger_, zmqContext_
-      , bip15xTransport);
-}
-
-std::unique_ptr<DataConnection> ConnectionManager::createZmqBIP15xDataConnection(
-   const std::shared_ptr<bs::network::TransportBIP15xClient> &transport) const
-{
-   auto conn = std::make_unique<ZmqBinaryConnection>(logger_, transport);
-   conn->SetContext(zmqContext_);
-   return conn;
-}
-
-std::shared_ptr<DataConnection> ConnectionManager::createZmqBIP15xDataConnection() const
-{
-   bs::network::BIP15xParams params;
-   params.ephemeralPeers = true;
-   const auto &transport = std::make_shared<bs::network::TransportBIP15xClient>(logger_, params);
-   auto conn = std::make_shared<ZmqBinaryConnection>(logger_, transport);
-   conn->SetContext(zmqContext_);
-   return conn;
 }
 
 std::shared_ptr<ServerConnection> ConnectionManager::CreatePubBridgeServerConnection() const

--- a/BlocksettleNetworkingLib/ConnectionManager.h
+++ b/BlocksettleNetworkingLib/ConnectionManager.h
@@ -58,14 +58,6 @@ public:
    std::shared_ptr<DataConnection>     CreateGenoaClientConnection(
       bool monitored = false) const;
 
-   std::unique_ptr<DataConnection>  createZmqBIP15xDataConnection(
-      const std::shared_ptr<bs::network::TransportBIP15xClient> &) const;
-   std::shared_ptr<DataConnection>  createZmqBIP15xDataConnection() const;
-
-   std::shared_ptr<ServerConnection> createZmqBIP15xChatServerConnection(
-      bool ephemeral = false, const std::string& ownKeyFileDir = ""
-      , const std::string& ownKeyFileName = "") const;
-
    std::shared_ptr<ServerConnection>   CreatePubBridgeServerConnection() const;
 
    std::shared_ptr<ServerConnection>   CreateMDRestServerConnection() const;

--- a/BlocksettleNetworkingLib/DataConnection.h
+++ b/BlocksettleNetworkingLib/DataConnection.h
@@ -52,7 +52,7 @@ protected:
 
    void detachFromListener();
 
-   virtual void onRawDataReceived(const std::string& rawData) = 0;
+   virtual void onRawDataReceived(const std::string& rawData) {}
 
    void notifyOnData(const std::string& data);
    virtual void notifyOnConnected();

--- a/BlocksettleNetworkingLib/GenoaConnection.h
+++ b/BlocksettleNetworkingLib/GenoaConnection.h
@@ -16,11 +16,6 @@
 #include <string>
 #include <memory>
 
-namespace bs {
-   namespace network {
-      class TransportClient;
-   }
-}
 namespace spdlog {
    class logger;
 }
@@ -29,13 +24,11 @@ template<class _S>
 class GenoaConnection : public _S
 {
 public:
-   GenoaConnection(const std::shared_ptr<spdlog::logger> &logger
-      , const std::shared_ptr<bs::network::TransportClient> &t = nullptr)
-      : _S(logger, t)
+   GenoaConnection(const std::shared_ptr<spdlog::logger> &logger)
+      : _S(logger)
    {}
-   GenoaConnection(const std::shared_ptr<spdlog::logger> &logger, bool monitored
-      , const std::shared_ptr<bs::network::TransportClient> &t = nullptr)
-      : _S(logger, t, monitored)
+   GenoaConnection(const std::shared_ptr<spdlog::logger> &logger, bool monitored)
+      : _S(logger, monitored)
    {}
 
    ~GenoaConnection() noexcept override = default;
@@ -50,7 +43,7 @@ public:
    bool send(const std::string& data) override
    {
       std::string message = data + marker;
-      return _S::sendData(message);
+      return _S::sendRawData(message);
    }
 
 protected:

--- a/BlocksettleNetworkingLib/GenoaStreamServerConnection.cpp
+++ b/BlocksettleNetworkingLib/GenoaStreamServerConnection.cpp
@@ -12,13 +12,11 @@
 
 #include "ActiveStreamClient.h"
 #include "GenoaConnection.h"
-#include "Transport.h"
 
 
 GenoaStreamServerConnection::GenoaStreamServerConnection(const std::shared_ptr<spdlog::logger>& logger
-   , const std::shared_ptr<ZmqContext>& context
-   , const std::shared_ptr<bs::network::TransportServer> &t)
-   : ZmqStreamServerConnection(logger, context, t)
+   , const std::shared_ptr<ZmqContext>& context)
+   : ZmqStreamServerConnection(logger, context)
 {}
 
 ZmqStreamServerConnection::server_connection_ptr GenoaStreamServerConnection::CreateActiveConnection()

--- a/BlocksettleNetworkingLib/GenoaStreamServerConnection.h
+++ b/BlocksettleNetworkingLib/GenoaStreamServerConnection.h
@@ -13,18 +13,11 @@
 
 #include "ZmqStreamServerConnection.h"
 
-namespace bs {
-   namespace network {
-      class TransportServer;
-   }
-}
-
 class GenoaStreamServerConnection : public ZmqStreamServerConnection
 {
 public:
    GenoaStreamServerConnection(const std::shared_ptr<spdlog::logger> &
-      , const std::shared_ptr<ZmqContext> &
-      , const std::shared_ptr<bs::network::TransportServer> &t = nullptr);
+      , const std::shared_ptr<ZmqContext> &);
    ~GenoaStreamServerConnection() noexcept = default;
 
    GenoaStreamServerConnection(const GenoaStreamServerConnection&) = delete;

--- a/BlocksettleNetworkingLib/HeadlessContainerListener.cpp
+++ b/BlocksettleNetworkingLib/HeadlessContainerListener.cpp
@@ -712,20 +712,14 @@ bool HeadlessContainerListener::onSignAuthAddrRevokeRequest(const std::string &c
          return;
       }
 
-      ValidationAddressManager validationMgr(nullptr);
-      auto addrObj = bs::Address::fromAddressString(request.validation_address());
-      validationMgr.addValidationAddress(addrObj);
-
       try {
-         {
-            const bs::core::WalletPasswordScoped passLock(walletsMgr_->getPrimaryWallet(), pass);
-            const auto lock = wallet->lockDecryptedContainer();
-            auto authAddr = bs::Address::fromAddressString(request.auth_address());
-            auto validationAddr = bs::Address::fromAddressString(request.validation_address());
-            const auto tx = AuthAddressLogic::revoke(authAddr, wallet->getResolver()
-               , validationAddr, utxo);
-            SignTXResponse(clientId, id, reqType, ErrorCode::NoError, tx);
-         }
+         const bs::core::WalletPasswordScoped passLock(walletsMgr_->getPrimaryWallet(), pass);
+         const auto lock = wallet->lockDecryptedContainer();
+         auto authAddr = bs::Address::fromAddressString(request.auth_address());
+         auto validationAddr = bs::Address::fromAddressString(request.validation_address());
+         const auto tx = AuthAddressLogic::revoke(authAddr, wallet->getResolver()
+            , validationAddr, utxo);
+         SignTXResponse(clientId, id, reqType, ErrorCode::NoError, tx);
       } catch (const std::exception &e) {
          logger_->error("[HeadlessContainerListener] failed to sign payout TX request: {}", e.what());
          SignTXResponse(clientId, id, reqType, ErrorCode::InternalError);

--- a/BlocksettleNetworkingLib/HeadlessContainerListener.h
+++ b/BlocksettleNetworkingLib/HeadlessContainerListener.h
@@ -50,8 +50,7 @@ class HeadlessContainerCallbacks
 public:
    virtual ~HeadlessContainerCallbacks() = default;
 
-   virtual void peerConn(const std::string &) = 0;
-   virtual void peerDisconn(const std::string &) = 0;
+   virtual void clientConn(const std::string &, const ServerConnectionListener::Details &details) = 0;
    virtual void clientDisconn(const std::string &) = 0;
 
    virtual void decryptWalletRequest(Blocksettle::Communication::signer::PasswordDialogType dialogType
@@ -127,12 +126,10 @@ protected:
 
    void onXbtSpent(const int64_t value, bool autoSign);
 
-   void OnClientConnected(const std::string &clientId) override;
+   void OnClientConnected(const std::string &clientId, const Details &details) override;
    void OnClientDisconnected(const std::string &clientId) override;
    void OnDataFromClient(const std::string &clientId, const std::string &data) override;
-   void OnPeerConnected(const std::string &ip) override;
-   void OnPeerDisconnected(const std::string &ip) override;
-   void onClientError(const std::string &clientId, ServerConnectionListener::ClientError errorCode, int socket) override;
+   void onClientError(const std::string &clientId, ClientError errorCode, const Details &details) override;
 
 private:
    void passwordReceived(const std::string &clientId, const std::string &walletId
@@ -217,7 +214,7 @@ private:
    const std::string                   backupPath_;
    const NetworkType                   netType_;
    bs::signer::Limits                  limits_;
-   std::unordered_set<std::string>     connectedClients_;
+   std::unordered_map<std::string, ServerConnectionListener::Details>     connectedClients_;
 
    std::unordered_map<std::string, SecureBinaryData>                 passwords_;
    //std::unordered_set<std::string>  autoSignPwdReqs_;

--- a/BlocksettleNetworkingLib/NetworkSettingsLoader.cpp
+++ b/BlocksettleNetworkingLib/NetworkSettingsLoader.cpp
@@ -12,7 +12,8 @@
 
 #include "RequestReplyCommand.h"
 #include "TransportBIP15x.h"
-#include "ZmqDataConnection.h"
+#include "Bip15xDataConnection.h"
+#include "WsDataConnection.h"
 #include "bs_communication.pb.h"
 
 
@@ -39,8 +40,8 @@ void NetworkSettingsLoader::loadSettings()
    params.ephemeralPeers = true;
    const auto &bip15xTransport = std::make_shared<bs::network::TransportBIP15xClient>(logger_, params);
    bip15xTransport->setKeyCb(cbApprove_);
-   auto connection = std::make_shared<ZmqBinaryConnection>(logger_, bip15xTransport);
-   connection->SetContext(std::make_shared<ZmqContext>(logger_));
+   auto wsConn = std::make_unique<WsDataConnection>(logger_, WsDataConnectionParams{});
+   auto connection = std::make_shared<Bip15xDataConnection>(logger_, std::move(wsConn), bip15xTransport);
 
    Blocksettle::Communication::RequestPacket reqPkt;
    reqPkt.set_requesttype(Blocksettle::Communication::GetNetworkSettingsType);

--- a/BlocksettleNetworkingLib/RouterServerConnection.cpp
+++ b/BlocksettleNetworkingLib/RouterServerConnection.cpp
@@ -45,9 +45,9 @@ public:
       listener_->OnDataFromClient(getRouterClientId(index_, clientId), data);
    }
 
-   void OnClientConnected(const std::string& clientId) override
+   void OnClientConnected(const std::string& clientId, const Details &details) override
    {
-      listener_->OnClientConnected(getRouterClientId(index_, clientId));
+      listener_->OnClientConnected(getRouterClientId(index_, clientId), details);
    }
 
    void OnClientDisconnected(const std::string& clientId) override
@@ -55,24 +55,9 @@ public:
       listener_->OnClientDisconnected(getRouterClientId(index_, clientId));
    }
 
-   void OnPeerConnected(const std::string &ip) override
+   void onClientError(const std::string &clientId, ClientError error, const Details &details) override
    {
-      listener_->OnPeerConnected(ip);
-   }
-
-   void OnPeerDisconnected(const std::string &ip) override
-   {
-      listener_->OnPeerDisconnected(ip);
-   }
-
-   void onClientError(const std::string &clientId, const std::string &error) override
-   {
-      listener_->onClientError(getRouterClientId(index_, clientId), error);
-   }
-
-   void onClientError(const std::string &clientId, ClientError errorCode, int socket) override
-   {
-      listener_->onClientError(getRouterClientId(index_, clientId), errorCode, socket);
+      listener_->onClientError(getRouterClientId(index_, clientId), error, details);
    }
 
    ServerConnectionListener *listener_{};
@@ -104,11 +89,6 @@ bool RouterServerConnection::BindConnection(const std::string& host , const std:
       index += 1;
    }
    return result;
-}
-
-std::string RouterServerConnection::GetClientInfo(const std::string &clientId) const
-{
-   return {};
 }
 
 bool RouterServerConnection::SendDataToClient(const std::string &clientId, const std::string &data)

--- a/BlocksettleNetworkingLib/RouterServerConnection.h
+++ b/BlocksettleNetworkingLib/RouterServerConnection.h
@@ -49,8 +49,6 @@ public:
    bool BindConnection(const std::string& host, const std::string& port
       , ServerConnectionListener* listener) override;
 
-   std::string GetClientInfo(const std::string &clientId) const override;
-
    bool SendDataToClient(const std::string& clientId, const std::string& data) override;
    bool SendDataToAllClients(const std::string&) override;
 

--- a/BlocksettleNetworkingLib/ServerConnection.h
+++ b/BlocksettleNetworkingLib/ServerConnection.h
@@ -17,12 +17,6 @@
 #include <memory>
 #include <string>
 
-namespace bs {
-   namespace network {
-      class TransportServer;
-   }
-}
-
 class ServerConnection
 {
 public:
@@ -38,12 +32,8 @@ public:
    virtual bool BindConnection(const std::string& host, const std::string& port
       , ServerConnectionListener* listener) = 0;
 
-   virtual std::string GetClientInfo(const std::string &clientId) const = 0;
-
    virtual bool SendDataToClient(const std::string& clientId, const std::string& data) = 0;
    virtual bool SendDataToAllClients(const std::string&) { return false; }
-
-   virtual void setTransport(const std::shared_ptr<bs::network::TransportServer> &) {}
 };
 
 #endif // __SERVER_CONNECTION_H__

--- a/BlocksettleNetworkingLib/ServerConnectionListener.h
+++ b/BlocksettleNetworkingLib/ServerConnectionListener.h
@@ -11,7 +11,7 @@
 #ifndef __SERVER_CONNECTION_LISTENER_H__
 #define __SERVER_CONNECTION_LISTENER_H__
 
-#include <memory>
+#include <map>
 #include <string>
 
 class ServerConnectionListener
@@ -19,11 +19,17 @@ class ServerConnectionListener
 public:
    enum ClientError
    {
-      NoError = 0,
-
       // Reported when client do not have valid credentials (unknown public key)
       HandshakeFailed = 1,
+      Timeout = 2,
    };
+
+   enum class Detail
+   {
+      IpAddr = 1,
+      PublicKey = 2,
+   };
+   using Details = std::map<Detail, std::string>;
 
    ServerConnectionListener() = default;
    virtual ~ServerConnectionListener() noexcept = default;
@@ -37,14 +43,10 @@ public:
 public:
    virtual void OnDataFromClient(const std::string& clientId, const std::string& data) = 0;
 
-   virtual void OnClientConnected(const std::string& clientId) = 0;
+   virtual void OnClientConnected(const std::string &clientId, const Details &details) = 0;
    virtual void OnClientDisconnected(const std::string& clientId) = 0;
 
-   virtual void OnPeerConnected(const std::string &ip) {}
-   virtual void OnPeerDisconnected(const std::string &ip) {}
-
-   virtual void onClientError(const std::string &clientId, const std::string &error) {}
-   virtual void onClientError(const std::string &clientId, ClientError errorCode, int socket) {}
+   virtual void onClientError(const std::string &clientId, ClientError error, const Details &details) {}
 };
 
 #endif // __SERVER_CONNECTION_LISTENER_H__

--- a/BlocksettleNetworkingLib/SignContainer.h
+++ b/BlocksettleNetworkingLib/SignContainer.h
@@ -52,9 +52,6 @@ public:
    enum class OpMode {
       Local = 1,
       Remote,
-      // RemoteInproc - should be used for testing only, when you need to have signer and listener
-      // running in same process and could not use TCP for any reason
-      RemoteInproc,
       LocalInproc
    };
    enum class TXSignMode {

--- a/BlocksettleNetworkingLib/TradeSettings.cpp
+++ b/BlocksettleNetworkingLib/TradeSettings.cpp
@@ -1,0 +1,33 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#include "TradeSettings.h"
+
+#include "bs_types.pb.h"
+
+using namespace bs;
+
+void TradeSettings::toPb(types::TradeSettings &msg)
+{
+   msg.set_xbt_tier1_limit(xbtTier1Limit);
+   msg.set_xbt_price_band(xbtPriceBand);
+   msg.set_auth_required_settled_trades(authRequiredSettledTrades);
+   msg.set_auth_submit_address_limit(authSubmitAddressLimit);
+}
+
+TradeSettings TradeSettings::fromPb(const types::TradeSettings &msg)
+{
+   TradeSettings result;
+   result.xbtTier1Limit = msg.xbt_tier1_limit();
+   result.xbtPriceBand = msg.xbt_price_band();
+   result.authRequiredSettledTrades = msg.auth_required_settled_trades();
+   result.authSubmitAddressLimit = msg.auth_submit_address_limit();
+   return result;
+}

--- a/BlocksettleNetworkingLib/TradeSettings.h
+++ b/BlocksettleNetworkingLib/TradeSettings.h
@@ -1,0 +1,34 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#ifndef TRADE_SETTINGS_H
+#define TRADE_SETTINGS_H
+
+#include <cinttypes>
+
+namespace bs {
+
+   namespace types {
+      class TradeSettings;
+   }
+
+   struct TradeSettings {
+      uint64_t xbtTier1Limit{};
+      uint32_t xbtPriceBand{};
+      uint32_t authRequiredSettledTrades{};
+      uint32_t authSubmitAddressLimit{};
+
+      void toPb(types::TradeSettings &msg);
+      static TradeSettings fromPb(const types::TradeSettings &msg);
+   };
+
+}
+
+#endif

--- a/BlocksettleNetworkingLib/Transport.h
+++ b/BlocksettleNetworkingLib/Transport.h
@@ -28,20 +28,10 @@ namespace bs {
 
          virtual std::string listenThreadName() const = 0;
 
-         virtual long pollTimeoutMS() const = 0;
-
-         virtual bool handshakeTimedOut() const = 0;
-         virtual bool connectTimedOut() const = 0;
-
-         virtual void startConnection() = 0;
          virtual void openConnection(const std::string &host, const std::string &port) = 0;
          virtual void closeConnection() = 0;
-         virtual void socketConnected() = 0;
-         virtual void socketDisconnected() = 0;
 
-         virtual void triggerHeartbeatCheck() = 0;
          virtual bool sendData(const std::string &) = 0;
-         virtual void sendDisconnect() = 0;
          virtual void startHandshake() = 0;
 
          virtual void onRawDataReceived(const std::string &) = 0;
@@ -68,18 +58,14 @@ namespace bs {
          virtual ~TransportServer() = default;
 
          virtual void processIncomingData(const std::string &encData
-            , const std::string &clientID, int socket) = 0;
-         virtual void periodicCheck() = 0;
+            , const std::string &clientID) = 0;
          virtual bool sendData(const std::string &clientId, const std::string &data) = 0;
+         virtual void addClient(const std::string &clientId, const ServerConnectionListener::Details &details) = 0;
+         virtual void closeClient(const std::string &clientId) = 0;
 
-         using ClientErrorCb = std::function<void(const std::string &id, const std::string &err)>;
-         using ClientSocketErrorCb = std::function<void(const std::string &clientId
-            , ServerConnectionListener::ClientError errorCode, int socket)>;
-         void setClientErrorCb(const ClientErrorCb &cb, const ClientSocketErrorCb &cbS)
-         {
-            clientErrorCb_ = cb;
-            clientSocketErrorCb_ = cbS;
-         }
+         using ClientErrorCb = std::function<void(const std::string &id, ServerConnectionListener::ClientError
+            , const ServerConnectionListener::Details &details)>;
+         void setClientErrorCb(const ClientErrorCb &cb) { clientErrorCb_ = cb; }
 
          using DataReceivedCb = std::function<void(const std::string &clientId, const std::string &data)>;
          void setDataReceivedCb(const DataReceivedCb &cb) { dataReceivedCb_ = cb; }
@@ -87,20 +73,18 @@ namespace bs {
          using SendDataCb = std::function<bool(const std::string &clientId, const std::string &data)>;
          void setSendDataCb(const SendDataCb &cb) { sendDataCb_ = cb; }
 
-         using ConnectedCb = std::function<void(const std::string &clientId)>;
-         void setConnectedCb(const ConnectedCb &connCb, const ConnectedCb &disconnCb)
-         {
-            connCb_ = connCb;
-            disconnCb_ = disconnCb;
-         }
+         using ConnectedCb = std::function<void(const std::string &clientId, const ServerConnectionListener::Details &details)>;
+         void setConnectedCb(const ConnectedCb &connCb) { connCb_ = connCb; }
+
+         using DisconnectedCb = std::function<void(const std::string &clientId)>;
+         void setDisconnectedCb(const DisconnectedCb &disconnCb) { disconnCb_ = disconnCb; }
 
       protected:
          ClientErrorCb        clientErrorCb_{ nullptr };
-         ClientSocketErrorCb  clientSocketErrorCb_{ nullptr };
          DataReceivedCb       dataReceivedCb_{ nullptr };
          SendDataCb           sendDataCb_{ nullptr };
          ConnectedCb          connCb_{ nullptr };
-         ConnectedCb          disconnCb_{ nullptr };
+         DisconnectedCb       disconnCb_{ nullptr };
       };
 
    }  // namespace network

--- a/BlocksettleNetworkingLib/TransportBIP15x.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15x.cpp
@@ -24,43 +24,13 @@
 
 using namespace bs::network;
 
-namespace
-{
-   const int HEARTBEAT_PACKET_SIZE = 23;
-
-   const int ControlSocketIndex = 0;
-   const int StreamSocketIndex = 1;
-   const int MonitorSocketIndex = 2;
-
-} // namespace
-
 
 TransportBIP15x::TransportBIP15x(const std::shared_ptr<spdlog::logger> &logger
    , const std::string &cookiePath)
    : logger_(logger), cookiePath_(cookiePath)
-   , heartbeatInterval_(getDefaultHeartbeatInterval())
 {
    assert(logger_);
    authPeers_ = std::make_unique<AuthorizedPeers>();
-
-   lastHeartbeatCheck_ = std::chrono::steady_clock::now();
-}
-
-// static
-const std::chrono::milliseconds TransportBIP15x::getDefaultHeartbeatInterval()
-{
-   return std::chrono::seconds(30);
-}
-
-// static
-const std::chrono::milliseconds TransportBIP15x::getLocalHeartbeatInterval()
-{
-   return std::chrono::seconds(5);
-}
-
-void TransportBIP15x::setLocalHeartbeatInterval()
-{
-   heartbeatInterval_ = getLocalHeartbeatInterval();
 }
 
 // static
@@ -97,7 +67,6 @@ BinaryData TransportBIP15x::getOwnPubKey(const AuthorizedPeers &authPeers)
 BinaryData TransportBIP15x::getOwnPubKey() const
 {
    std::lock_guard<std::mutex> lock(authPeersMutex_);
-   const auto pubKey = authPeers_->getOwnPublicKey();
    return getOwnPubKey(*authPeers_);
 }
 
@@ -459,23 +428,13 @@ void TransportBIP15xClient::rekeyIfNeeded(size_t dataSize)
    }
 }
 
-void TransportBIP15xClient::startConnection()
-{
-   connectionStarted_ = std::chrono::steady_clock::now();;
-}
-
-long TransportBIP15xClient::pollTimeoutMS() const
-{
-   const long toMS = isConnected_ ? (heartbeatInterval_ / std::chrono::milliseconds(1) / 5)
-      : (params_.connectionTimeout / std::chrono::milliseconds(1) / 10);
-   return std::max((long)1, toMS);
-}
-
 bool TransportBIP15xClient::sendData(const std::string &data)
 {
    if (!bip151Connection_ || (bip151Connection_->getBIP150State() != BIP150State::SUCCESS)) {
       return false;
    }
+
+   rekeyIfNeeded(data.size());
 
    auto packet = bip15x::MessageBuilder(BinaryData::fromString(data)
       , bip15x::MsgType::SinglePacket).encryptIfNeeded(bip151Connection_.get()).build();
@@ -503,10 +462,6 @@ bool TransportBIP15xClient::sendPacket(const BinaryData &packet, bool encrypted)
       }
    }
 
-   if (encrypted && !rekeying_) {
-      rekeyIfNeeded(packet.getSize());
-   }
-
    return sendCb_(packet.toBinStr());
 }
 
@@ -524,57 +479,15 @@ void TransportBIP15xClient::rekey()
    BinaryData rekeyData(BIP151PUBKEYSIZE);
    memset(rekeyData.getPtr(), 0, BIP151PUBKEYSIZE);
 
-   rekeying_ = true;
-   auto packet = bip15x::MessageBuilder(rekeyData.getRef()
+   auto packet = bip15x::MessageBuilder(rekeyData
       , bip15x::MsgType::AEAD_Rekey).encryptIfNeeded(bip151Connection_.get()).build();
+   logger_->debug("[TransportBIP15xClient::rekey] rekeying session ({} {})"
+      , rekeyData.toHexStr(), packet.toHexStr());
    sendPacket(packet);
    bip151Connection_->rekeyOuterSession();
    ++outerRekeyCount_;
-   rekeying_ = false;
 }
 
-// A function that is used to trigger heartbeats. Required because ZMQ is unable
-// to tell, via a data socket connection, when a client has disconnected.
-//
-// INPUT:  N/A
-// OUTPUT: N/A
-// RETURN: N/A
-void TransportBIP15xClient::triggerHeartbeatCheck()
-{
-   if (!bip151HandshakeCompleted_) {
-      return;
-   }
-
-   const auto now = std::chrono::steady_clock::now();
-   const auto idlePeriod = now - lastHeartbeatCheck_;
-   if (idlePeriod < heartbeatInterval_) {
-      return;
-   }
-   lastHeartbeatCheck_ = now;
-
-   // If a rekey is needed, rekey before encrypting. Estimate the size of the
-   // final packet first in order to get the # of bytes transmitted.
-   rekeyIfNeeded(HEARTBEAT_PACKET_SIZE);
-
-   auto packet = bip15x::MessageBuilder(bip15x::MsgType::Heartbeat)
-      .encryptIfNeeded(bip151Connection_.get()).build();
-
-   // An error message is already logged elsewhere if the send fails.
-   // sendPacket already sets the timestamp.
-   sendPacket(packet);
-
-   if (idlePeriod > heartbeatInterval_ * 2) {
-      logger_->debug("[TransportBIP15xClient:triggerHeartbeatCheck] hibernation"
-         " detected, reset server's last timestamp");
-      lastHeartbeatReply_ = now;
-      return;
-   }
-
-   auto lastHeartbeatDiff = now - lastHeartbeatReply_;
-   if (socketErrorCb_ && (lastHeartbeatDiff > heartbeatInterval_ * 2)) {
-      socketErrorCb_(DataConnectionListener::HeartbeatWaitFailed);
-   }
-}
 
 // Kick off the BIP 151 handshake. This is the first function to call once the
 // unencrypted connection is established.
@@ -603,52 +516,37 @@ void TransportBIP15xClient::onRawDataReceived(const std::string &rawData)
       return;
    }
 
-   const auto &packets = bip15x::MessageBuilder::parsePackets(
-      BinaryData::fromString(accumulBuf_.empty() ? rawData : accumulBuf_ + rawData));
-   if (packets.empty()) {
-      logger_->error("[TransportBIP15xClient::processIncomingData] packet deser failed"
-         " for {} [{}]", bs::toHex(rawData), rawData.size());
-      if (socketErrorCb_) {
-         socketErrorCb_(DataConnectionListener::SerializationFailed);
-      }
+   auto payload = BinaryData::fromString(rawData);
+   if (!bip151Connection_) {
+      logger_->error("[TransportBIP15xClient::onRawDataReceived] received {}-sized"
+         " packet in disconnected state", payload.getSize());
       return;
    }
-   if (packets.at(0).empty()) {  // special condition to accumulate more data
-      accumulBuf_.append(rawData);
-      return;
-   }
-   accumulBuf_.clear();
+   // Perform decryption if we're ready.
+   if (bip151Connection_->connectionComplete()) {
+      auto result = bip151Connection_->decryptPacket(
+         payload.getPtr(), payload.getSize(),
+         payload.getPtr(), payload.getSize());
 
-   for (auto payload : packets) {
-      if (!bip151Connection_) {
-         logger_->error("[TransportBIP15xClient::onRawDataReceived] received {}-sized"
-            " packet in disconnected state", payload.getSize());
+      if (result != 0) {
+         logger_->error("[TransportBIP15xClient::onRawDataReceived] Packet [{} bytes]"
+            " decryption failed - error {}", payload.getSize(), result);
+         if (socketErrorCb_) {
+            socketErrorCb_(DataConnectionListener::ProtocolViolation);
+         }
+         fail();
          return;
       }
-      // Perform decryption if we're ready.
-      if (bip151Connection_->connectionComplete()) {
-         auto result = bip151Connection_->decryptPacket(
-            payload.getPtr(), payload.getSize(),
-            payload.getPtr(), payload.getSize());
-
-         if (result != 0) {
-            logger_->error("[TransportBIP15xClient::onRawDataReceived] Packet [{} bytes]"
-               " decryption failed - error {}", payload.getSize(), result);
-            if (socketErrorCb_) {
-               socketErrorCb_(DataConnectionListener::ProtocolViolation);
-            }
-            fail();
-            return;
-         }
-         payload.resize(payload.getSize() - POLY1305MACLEN);
-      }
-      processIncomingData(payload);
+      payload.resize(payload.getSize() - POLY1305MACLEN);
    }
+   processIncomingData(payload);
 }
 
 void TransportBIP15xClient::openConnection(const std::string &host
    , const std::string &port)
 {
+   closeConnection();
+
    host_ = host;
    port_ = port;
 
@@ -656,20 +554,15 @@ void TransportBIP15xClient::openConnection(const std::string &host
    // similar but data connections will only connect to one machine at a time.
    auto lbds = getAuthPeerLambda();
    bip151Connection_ = std::make_unique<BIP151Connection>(lbds);
-
-   isConnected_ = false;
-   serverSendsHeartbeat_ = false;
 }
 
 void TransportBIP15xClient::closeConnection()
 {
-   // Do not call from callbacks!
    // If a future obj is still waiting, satisfy it to prevent lockup. This
    // shouldn't happen here but it's an emergency fallback.
    if (serverPubkeyProm_) {
       serverPubkeyProm_->setValue(false);
    }
-   sendDisconnect();
 
    SPDLOG_LOGGER_DEBUG(logger_, "[TransportBIP15xClient::closeConnection]");
 
@@ -692,12 +585,6 @@ void TransportBIP15xClient::processIncomingData(const BinaryData &payload)
       if (socketErrorCb_) {
          socketErrorCb_(DataConnectionListener::SerializationFailed);
       }
-      return;
-   }
-
-   if (msg.getType() == bip15x::MsgType::Heartbeat) {
-      lastHeartbeatReply_ = std::chrono::steady_clock::now();
-      serverSendsHeartbeat_ = true;
       return;
    }
 
@@ -856,8 +743,6 @@ bool TransportBIP15xClient::processAEADHandshake(const bip15x::Message &msgObj)
 
          auto now = std::chrono::steady_clock::now();
          outKeyTimePoint_ = now;
-         lastHeartbeatReply_ = now;
-         lastHeartbeatCheck_ = now;
 
          logger_->debug("[TransportBIP15xClient::processAEADHandshake] BIP 150 handshake"
             " with server complete - connection to {} is ready and fully secured", srvId);
@@ -971,17 +856,4 @@ bool TransportBIP15xClient::getCookie(BinaryData &cookieBuf)
       return false;
    }
    return TransportBIP15x::getCookie(cookieBuf);
-}
-
-void TransportBIP15xClient::sendDisconnect()
-{
-   if (!bip151Connection_ || (bip151Connection_->getBIP150State() != BIP150State::SUCCESS)) {
-      return;
-   }
-   logger_->debug("[TransportBIP15xClient::sendDisconnect]");
-
-   auto packet = bip15x::MessageBuilder(bip15x::MsgType::Disconnect)
-      .encryptIfNeeded(bip151Connection_.get()).build();
-   // An error message is already logged elsewhere if the send fails.
-   sendPacket(packet);
 }

--- a/BlocksettleNetworkingLib/TransportBIP15x.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15x.cpp
@@ -467,6 +467,9 @@ bool TransportBIP15xClient::sendPacket(const BinaryData &packet, bool encrypted)
 
 void TransportBIP15xClient::rekey()
 {
+   //XXX : rekey disabled
+   return;
+
    logger_->debug("[TransportBIP15xClient::rekey] rekeying");
 
    if (!bip150HandshakeCompleted_) {

--- a/BlocksettleNetworkingLib/TransportBIP15x.h
+++ b/BlocksettleNetworkingLib/TransportBIP15x.h
@@ -104,16 +104,6 @@ namespace bs {
          void addAuthPeer(const BIP15xPeer &);
          void updatePeerKeys(const BIP15xPeers &);
 
-         void setLocalHeartbeatInterval();
-         void setHeartbeatInterval(const std::chrono::milliseconds &hbi)
-         {
-            heartbeatInterval_ = hbi;
-         }
-
-         // There was some issues with static field initalization order so use static function here
-         static const std::chrono::milliseconds getDefaultHeartbeatInterval();
-         static const std::chrono::milliseconds getLocalHeartbeatInterval();
-
          static BinaryData getOwnPubKey(const std::string &ownKeyFileDir, const std::string &ownKeyFileName);
          static BinaryData getOwnPubKey(const AuthorizedPeers &authPeers);
 
@@ -140,9 +130,6 @@ namespace bs {
          mutable std::mutex authPeersMutex_;
          std::string cookiePath_;
 
-         std::chrono::milliseconds heartbeatInterval_;
-         std::chrono::steady_clock::time_point lastHeartbeatCheck_{};
-
       private:
          bool isValid_{ true };
          std::unique_ptr<std::ofstream>   cookieFile_;   //Need to keep opened for the whole object lifetime
@@ -165,39 +152,14 @@ namespace bs {
 
          std::string listenThreadName() const override { return "listenBIP15x"; }
 
-         bool handshakeTimedOut() const override
-         {
-            return (bip151HandshakeCompleted_ && !bip150HandshakeCompleted_);
-         }
-
-         bool connectTimedOut() const override
-         {
-            return (!isConnected_
-               && std::chrono::steady_clock::now() - connectionStarted_ > params_.connectionTimeout);
-         }
-
          // thread-safe (could be called from callbacks too)
          void onRawDataReceived(const std::string &) override;
 
          void openConnection(const std::string &host, const std::string &port) override;
 
-         void startConnection() override;
-
-         // Do not call from callbacks!
          void closeConnection() override;
 
-         void socketConnected() override
-         {
-            isConnected_ = true;
-         }
-         void socketDisconnected() override
-         {
-            isConnected_ = false;
-         }
-
-         long pollTimeoutMS() const override;
          bool sendData(const std::string &data) override;
-         void sendDisconnect() override;
 
          void startHandshake() override
          {
@@ -210,8 +172,6 @@ namespace bs {
       private:
          bool createCookie() override;
          bool startBIP151Handshake();
-
-         void triggerHeartbeatCheck() override;
 
          void processIncomingData(const BinaryData &payload);
          bool processAEADHandshake(const bip15x::Message &);
@@ -230,16 +190,8 @@ namespace bs {
          uint32_t innerRekeyCount_ = 0;
          bool bip150HandshakeCompleted_ = false;
          bool bip151HandshakeCompleted_ = false;
-         bool rekeying_ = false;
-         std::string accumulBuf_;
 
          BIP15xNewKeyCb cbNewKey_;
-
-         // Reset this in openConnection
-         bool                             isConnected_{};
-         bool                             serverSendsHeartbeat_{};
-         std::chrono::steady_clock::time_point connectionStarted_{};
-         std::chrono::steady_clock::time_point lastHeartbeatReply_{};
       };
 
    }  // namespace network

--- a/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
@@ -147,6 +147,9 @@ TransportBIP15xServer::~TransportBIP15xServer() noexcept
 
 void TransportBIP15xServer::rekey(const std::string &clientId)
 {
+   //XXX : rekey disabled
+   return;
+
    auto connection = GetConnection(clientId);
    if (connection == nullptr) {
       logger_->error("[TransportBIP15xServer::rekey] can't find connection for {}", BinaryData::fromString(clientId).toHexStr());

--- a/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
@@ -19,12 +19,6 @@
 
 using namespace bs::network;
 
-namespace {
-   // How often we should check heartbeats in one heartbeatInterval_.
-   const int kHeartbeatsCheckCount = 5;
-
-} // namespace
-
 // A call resetting the encryption-related data for individual connections.
 //
 // INPUT:  None
@@ -252,7 +246,6 @@ void TransportBIP15xServer::processIncomingData(const std::string &encData
    if (msg.getType() > bip15x::MsgType::AEAD_Threshold) {
       if (!processAEADHandshake(msg, clientID)) {
          reportFatalError(connData);
-         return;
       }
       return;
    }

--- a/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
@@ -217,9 +217,6 @@ void TransportBIP15xServer::processIncomingData(const std::string &encData
    assert(connData);
    if (!connData->isValid) {
       return;
-      logger_->debug("[TransportBIP15xServer::processIncomingData] disconnected/invalid"
-         " client {} connection sent {} bytes", bs::toHex(clientID), encData.size(), encData.size());
-      return;
    }
 
    auto payload = BinaryData::fromString(encData);

--- a/BlocksettleNetworkingLib/WsConnection.cpp
+++ b/BlocksettleNetworkingLib/WsConnection.cpp
@@ -8,10 +8,12 @@
 **********************************************************************************
 
 */
-
 #include "WsConnection.h"
 
 #include <libwebsockets.h>
+#include <spdlog/spdlog.h>
+
+#include "BinaryData.h"
 
 using namespace bs::network;
 
@@ -21,20 +23,152 @@ namespace {
 
    constexpr size_t kLwsPrePaddingSize = LWS_PRE;
 
+   class WsRawPacketBuilder
+   {
+   private:
+      BinaryWriter w;
+
+   public:
+      WsRawPacketBuilder(WsPacket::Type type)
+      {
+         w.put_uint8_t(static_cast<uint8_t>(type));
+      }
+
+      WsRawPacketBuilder &putString(const std::string &data)
+      {
+         w.put_var_int(data.size());
+         w.put_String(data);
+         return *this;
+      }
+
+      WsRawPacketBuilder &putNumber(uint64_t n)
+      {
+         w.put_var_int(n);
+         return *this;
+      }
+
+      WsRawPacket build()
+      {
+         return WsRawPacket(w.toString());
+      }
+   };
 }
 
-WsPacket::WsPacket(const std::string &data)
+WsRawPacket::WsRawPacket(const std::string &data)
 {
    data_.resize(kLwsPrePaddingSize);
    data_.insert(data_.end(), data.begin(), data.end());
 }
 
-uint8_t *WsPacket::getPtr()
+uint8_t *WsRawPacket::getPtr()
 {
    return data_.data() + kLwsPrePaddingSize;
 }
 
-size_t WsPacket::getSize() const
+size_t WsRawPacket::getSize() const
 {
    return data_.size() - kLwsPrePaddingSize;
+}
+
+using namespace bs::network;
+
+WsRawPacket WsPacket::requestNew()
+{
+   return WsRawPacketBuilder(Type::RequestNew)
+         .build();
+}
+
+WsRawPacket WsPacket::requestResumed(const std::string &cookie, uint64_t recvCounter)
+{
+   return WsRawPacketBuilder(Type::RequestResumed)
+         .putNumber(recvCounter)
+         .putString(cookie)
+         .build();
+}
+
+WsRawPacket WsPacket::responseNew(const std::string &cookie)
+{
+   return WsRawPacketBuilder(Type::ResponseNew)
+         .putString(cookie)
+         .build();
+}
+
+WsRawPacket WsPacket::responseResumed(uint64_t recvCounter)
+{
+   return WsRawPacketBuilder(Type::ResponseResumed)
+         .putNumber(recvCounter)
+         .build();
+}
+
+WsRawPacket WsPacket::responseUnknown()
+{
+   return WsRawPacketBuilder(Type::ResponseUnknown)
+         .build();
+}
+
+WsRawPacket WsPacket::data(const std::string &payload)
+{
+   return WsRawPacketBuilder(Type::Data)
+         .putString(payload)
+         .build();
+}
+
+WsRawPacket WsPacket::close()
+{
+   return WsRawPacketBuilder(Type::Close)
+         .build();
+}
+
+WsRawPacket WsPacket::ack(uint64_t recvCounter)
+{
+   return WsRawPacketBuilder(Type::Ack)
+         .putNumber(recvCounter)
+         .build();
+}
+
+WsPacket WsPacket::parsePacket(const std::string &data, const std::shared_ptr<spdlog::logger> &logger)
+{
+   try {
+      WsPacket result;
+      BinaryRefReader r(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+
+      result.type = static_cast<Type>(r.get_uint8_t());
+      if (result.type < Type::Min || result.type > Type::Max) {
+         throw std::runtime_error("invalid packet type");
+      }
+
+      switch (result.type) {
+         case Type::RequestResumed:
+         case Type::ResponseResumed:
+         case Type::Ack:
+            result.recvCounter = r.get_var_int();
+            break;
+         default:
+            break;
+      }
+
+      switch (result.type) {
+         case Type::RequestResumed:
+         case Type::ResponseNew:
+         case Type::Data: {
+            auto payloadSize = r.get_var_int();
+            if (r.getSizeRemaining() < payloadSize) {
+               throw std::runtime_error("invalid packet");
+            }
+            result.payload = r.get_String(static_cast<uint32_t>(payloadSize));
+            break;
+         }
+         default:
+            break;
+      }
+
+      if (!r.isEndOfStream()) {
+         throw std::runtime_error("expecting end of stream");
+      }
+
+      return result;
+   } catch (const std::exception &e) {
+      SPDLOG_LOGGER_ERROR(logger, "invalid packet: {}", e.what());
+      return {};
+   }
 }

--- a/BlocksettleNetworkingLib/WsConnection.cpp
+++ b/BlocksettleNetworkingLib/WsConnection.cpp
@@ -113,12 +113,6 @@ WsRawPacket WsPacket::data(const std::string &payload)
          .build();
 }
 
-WsRawPacket WsPacket::close()
-{
-   return WsRawPacketBuilder(Type::Close)
-         .build();
-}
-
 WsRawPacket WsPacket::ack(uint64_t recvCounter)
 {
    return WsRawPacketBuilder(Type::Ack)

--- a/BlocksettleNetworkingLib/WsConnection.h
+++ b/BlocksettleNetworkingLib/WsConnection.h
@@ -63,10 +63,9 @@ namespace bs {
             ResponseUnknown = 0x15,
             Data = 0x16,
             Ack = 0x17,
-            Close = 0x18,
 
             Min = RequestNew,
-            Max = Close,
+            Max = Ack,
          };
 
          Type type{};
@@ -80,7 +79,6 @@ namespace bs {
          static WsRawPacket responseUnknown();
          static WsRawPacket data(const std::string &payload);
          static WsRawPacket ack(uint64_t recvCounter);
-         static WsRawPacket close();
 
          static WsPacket parsePacket(const std::string &payload
             , const std::shared_ptr<spdlog::logger> &logger);

--- a/BlocksettleNetworkingLib/WsConnection.h
+++ b/BlocksettleNetworkingLib/WsConnection.h
@@ -13,20 +13,29 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
+namespace spdlog {
+   class logger;
+}
+
 namespace bs {
    namespace network {
+      namespace ws {
 
-      class WsPacket
+         constexpr size_t kDefaultMaximumWsPacketSize = 100 * 1024 * 1024;
+
+      }
+      class WsRawPacket
       {
       private:
          // Actual data padded by LWS_PRE
          std::vector<uint8_t> data_;
 
       public:
-         explicit WsPacket(const std::string &data);
+         explicit WsRawPacket(const std::string &data);
 
          uint8_t *getPtr();
 
@@ -40,6 +49,42 @@ namespace bs {
       constexpr int kId = 0;
 
       constexpr auto kPingPongInterval = std::chrono::seconds(30);
+
+
+      struct WsPacket
+      {
+         enum class Type : uint8_t
+         {
+            Invalid = 0,
+            RequestNew = 0x11,
+            RequestResumed = 0x12,
+            ResponseNew = 0x13,
+            ResponseResumed = 0x14,
+            ResponseUnknown = 0x15,
+            Data = 0x16,
+            Ack = 0x17,
+            Close = 0x18,
+
+            Min = RequestNew,
+            Max = Close,
+         };
+
+         Type type{};
+         std::string payload;
+         uint64_t recvCounter{};
+
+         static WsRawPacket requestNew();
+         static WsRawPacket requestResumed(const std::string &cookie, uint64_t recvCounter);
+         static WsRawPacket responseNew(const std::string &cookie);
+         static WsRawPacket responseResumed(uint64_t recvCounter);
+         static WsRawPacket responseUnknown();
+         static WsRawPacket data(const std::string &payload);
+         static WsRawPacket ack(uint64_t recvCounter);
+         static WsRawPacket close();
+
+         static WsPacket parsePacket(const std::string &payload
+            , const std::shared_ptr<spdlog::logger> &logger);
+      };
 
    }
 }

--- a/BlocksettleNetworkingLib/WsDataConnection.cpp
+++ b/BlocksettleNetworkingLib/WsDataConnection.cpp
@@ -187,7 +187,7 @@ int WsDataConnection::callback(lws *wsi, int reason, void *user, void *in, size_
          }
 
          if (shuttingDown_.load()) {
-            if (state_ == State::Connected) {
+            if (state_ == State::Connected || state_ == State::Closing) {
                assert(wsi_);
                state_ = State::Closing;
                lws_callback_on_writable(wsi_);

--- a/BlocksettleNetworkingLib/WsDataConnection.cpp
+++ b/BlocksettleNetworkingLib/WsDataConnection.cpp
@@ -127,7 +127,8 @@ bool WsDataConnection::send(const std::string &data)
    if (!context_) {
       return false;
    }
-   {  std::lock_guard<std::mutex> lock(mutex_);
+   {
+      std::lock_guard<std::mutex> lock(mutex_);
       newPackets_.push(WsPacket::data(data));
    }
    lws_cancel_service(context_);
@@ -170,7 +171,8 @@ int WsDataConnection::callback(lws *wsi, int reason, void *user, void *in, size_
       }
 
       case LWS_CALLBACK_EVENT_WAIT_CANCELLED: {
-         {  std::lock_guard<std::mutex> lock(mutex_);
+         {
+            std::lock_guard<std::mutex> lock(mutex_);
             while (!newPackets_.empty()) {
                allPackets_.insert(std::make_pair(queuedCounter_, std::move(newPackets_.front())));
                newPackets_.pop();

--- a/BlocksettleNetworkingLib/WsDataConnection.h
+++ b/BlocksettleNetworkingLib/WsDataConnection.h
@@ -82,6 +82,9 @@ private:
    void requestWriteIfNeeded();
    bool processSentAck(uint64_t sentAckCounter);
 
+   // For tests, default is noop
+   virtual bs::network::WsRawPacket filterRawPacket(bs::network::WsRawPacket packet);
+
    std::shared_ptr<spdlog::logger> logger_;
    const WsDataConnectionParams params_;
 

--- a/BlocksettleNetworkingLib/WsDataConnection.h
+++ b/BlocksettleNetworkingLib/WsDataConnection.h
@@ -108,6 +108,7 @@ private:
    std::string cookie_;
    std::unique_ptr<WsTimerStruct> reconnectTimer_;
    uint16_t retryCounter_{};
+   bool shuttingDownReceived_{};
 
 };
 

--- a/BlocksettleNetworkingLib/WsDataConnection.h
+++ b/BlocksettleNetworkingLib/WsDataConnection.h
@@ -15,6 +15,7 @@
 #include "WsConnection.h"
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -23,26 +24,22 @@
 namespace spdlog {
    class logger;
 }
-namespace bs {
-   namespace network {
-      class TransportClient;
-   }
-}
-
+struct WsTimerStruct;
 struct lws_context;
+struct lws_sorted_usec_list;
 
-/*struct WsDataConnectionParams
+struct WsDataConnectionParams
 {
    const void *caBundlePtr{};
    uint32_t caBundleSize{};
-   bool useSsl{true};
-};*/
+   bool useSsl{false};
+   size_t maximumPacketSize{bs::network::ws::kDefaultMaximumWsPacketSize};
+};
 
 class WsDataConnection : public DataConnection
 {
 public:
-   WsDataConnection(const std::shared_ptr<spdlog::logger> &
-      , const std::shared_ptr<bs::network::TransportClient> &);
+   WsDataConnection(const std::shared_ptr<spdlog::logger>& logger, WsDataConnectionParams params);
    ~WsDataConnection() override;
 
    WsDataConnection(const WsDataConnection&) = delete;
@@ -55,39 +52,62 @@ public:
    bool closeConnection() override;
 
    bool send(const std::string& data) override;
-   bool isActive() const override { return active_; }
+   bool isActive() const override;
 
    static int callbackHelper(struct lws *wsi, int reason, void *user, void *in, size_t len);
 
 private:
+   enum class State
+   {
+      Connecting,
+      Reconnecting,
+      WaitingNewResponse,
+      WaitingResumedResponse,
+      Connected,
+      Closing,
+      Closed,
+   };
+
    int callback(struct lws *wsi, int reason, void *user, void *in, size_t len);
+
+   static void reconnectCallback(lws_sorted_usec_list *list);
 
    void listenFunction();
 
-   bool sendRawData(const std::string &);
-   void onRawDataReceived(const std::string& rawData) override;
-
-   void reportFatalError(DataConnectionListener::DataConnectionError error);
+   void scheduleReconnect();
+   void reconnect();
+   void processError();
+   void processFatalError();
+   bool writeNeeded() const;
+   void requestWriteIfNeeded();
+   bool processSentAck(uint64_t sentAckCounter);
 
    std::shared_ptr<spdlog::logger> logger_;
-//   const WsDataConnectionParams params_;
-   std::shared_ptr<bs::network::TransportClient>   transport_;
+   const WsDataConnectionParams params_;
 
    lws_context *context_{};
    std::string host_;
    int port_{};
-   std::atomic_bool stopped_{};
-   bool  active_{ false };
+   std::atomic_bool shuttingDown_{};
 
    std::thread listenThread_;
 
-   std::recursive_mutex mutex_;
-   std::queue<bs::network::WsPacket> newPackets_;
+   std::mutex mutex_;
+   std::queue<bs::network::WsRawPacket> newPackets_;
 
    // Fields accessible from listener thread only!
-   std::queue<bs::network::WsPacket> allPackets_;
+   std::map<uint64_t, bs::network::WsRawPacket> allPackets_;
    std::string currFragment_;
    lws *wsi_{};
+   State state_{State::Connecting};
+   uint64_t sentCounter_{};
+   uint64_t sentAckCounter_{};
+   uint64_t queuedCounter_{};
+   uint64_t recvCounter_{};
+   uint64_t recvAckCounter_{};
+   std::string cookie_;
+   std::unique_ptr<WsTimerStruct> reconnectTimer_;
+   uint16_t retryCounter_{};
 
 };
 

--- a/BlocksettleNetworkingLib/WsServerConnection.cpp
+++ b/BlocksettleNetworkingLib/WsServerConnection.cpp
@@ -378,7 +378,7 @@ int WsServerConnection::callback(lws *wsi, int reason, void *in, size_t len)
                connection.clientId = clientId;
                ServerConnectionListener::Details details;
                details[ServerConnectionListener::Detail::IpAddr] = connection.ipAddr;
-               SPDLOG_LOGGER_DEBUG(logger_, "new session started for client {}", clientId);
+               SPDLOG_LOGGER_DEBUG(logger_, "new session started for client {}", bs::toHex(clientId));
                listener_->OnClientConnected(clientId, details);
                lws_callback_on_writable(wsi);
                return 0;

--- a/BlocksettleNetworkingLib/WsServerConnection.cpp
+++ b/BlocksettleNetworkingLib/WsServerConnection.cpp
@@ -37,7 +37,13 @@ namespace {
       { nullptr, nullptr, 0, 0, 0, nullptr, 0 },
    };
 
-   const std::string kAllClientsId = "<TO_ALL>";
+   // Make sure that regular clientId can't clash with that
+   const auto kAllClientsId = std::string({'\0'});
+
+   std::string generateNewCookie()
+   {
+      return CryptoPRNG::generateRandom(32).toBinStr();
+   }
 
 } // namespace
 
@@ -372,7 +378,7 @@ int WsServerConnection::callback(lws *wsi, int reason, void *in, size_t len)
                return 0;
             }
             case State::SendingHandshakeNew: {
-               auto cookie = CryptoPRNG::generateRandom(32).toBinStr();
+               auto cookie = params_.testCookieGenerator ? params_.testCookieGenerator() : generateNewCookie();
                auto packet = WsPacket::responseNew(cookie);
                int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
                if (rc == -1) {

--- a/BlocksettleNetworkingLib/WsServerConnection.cpp
+++ b/BlocksettleNetworkingLib/WsServerConnection.cpp
@@ -10,10 +10,12 @@
 */
 #include "WsServerConnection.h"
 
+#include "BinaryData.h"
+#include "EncryptionUtils.h"
 #include "StringUtils.h"
 #include "ThreadName.h"
-#include "Transport.h"
 #include "WsConnection.h"
+#include "ZmqHelperFunctions.h"
 
 #include <random>
 #include <libwebsockets.h>
@@ -23,34 +25,33 @@ using namespace bs::network;
 
 namespace {
 
-   const auto kPeriodicCheckTimeout = std::chrono::seconds(30);
+   const auto kClientTimeout = std::chrono::seconds(30);
 
    int callback(lws *wsi, lws_callback_reasons reason, void *user, void *in, size_t len)
    {
       return WsServerConnection::callbackHelper(wsi, reason, in, len);
    }
+
    struct lws_protocols kProtocols[] = {
-   { kProtocolNameWs, callback, 0, kRxBufferSize, kId, nullptr, kTxPacketSize },
+      { kProtocolNameWs, callback, 0, kRxBufferSize, kId, nullptr, kTxPacketSize },
       { nullptr, nullptr, 0, 0, 0, nullptr, 0 },
    };
 
+   const std::string kAllClientsId = "<TO_ALL>";
+
 } // namespace
 
-WsServerConnection::WsServerConnection(const std::shared_ptr<spdlog::logger>& logger
-   , const std::shared_ptr<bs::network::TransportServer> &tr)
-   : logger_(logger)
-   , transport_(tr)
+struct WsServerTimer : lws_sorted_usec_list_t
 {
-   transport_->setClientErrorCb(
-      [this](const std::string &id, const std::string &err) { listener_->onClientError(id, err); }
-      , [this](const std::string &clientId, ServerConnectionListener::ClientError errorCode
-         , int socket) { listener_->onClientError(clientId, errorCode, socket); });
-   transport_->setDataReceivedCb([this](const std::string &clientId, const std::string &data) {
-      listener_->OnDataFromClient(clientId, data); });
-   transport_->setSendDataCb([this](const std::string &clientId, const std::string &data) {
-      return sendData(clientId, data); });
-   transport_->setConnectedCb([this](const std::string &clientId) { listener_->OnClientConnected(clientId); }
-      , [this](const std::string &clientId) { listener_->OnClientDisconnected(clientId); });
+   WsServerConnection *owner_{};
+   uint64_t timerId{};
+   WsServerConnection::TimerCallback callback;
+};
+
+WsServerConnection::WsServerConnection(const std::shared_ptr<spdlog::logger>& logger, WsServerConnectionParams params)
+   : logger_(logger)
+   , params_(std::move(params))
+{
 }
 
 WsServerConnection::~WsServerConnection()
@@ -84,7 +85,7 @@ bool WsServerConnection::BindConnection(const std::string& host , const std::str
       return false;
    }
 
-   stopped_ = false;
+   shuttingDown_ = false;
    listener_ = listener;
 
    listenThread_ = std::thread(&WsServerConnection::listenFunction, this);
@@ -96,9 +97,8 @@ void WsServerConnection::listenFunction()
 {
    bs::setCurrentThreadName("WsServer");
 
-   while (!stopped_.load()) {
-      lws_service(context_, kPeriodicCheckTimeout / std::chrono::milliseconds(1));
-      transport_->periodicCheck();
+   while (!done()) {
+      lws_service(context_, 0);
    }
 }
 
@@ -108,7 +108,11 @@ void WsServerConnection::stopServer()
       return;
    }
 
-   stopped_ = true;
+   DataToSend toSend{kAllClientsId, WsPacket::close()};
+   {  std::lock_guard<std::mutex> lock(mutex_);
+      packets_.push(std::move(toSend));
+   }
+   shuttingDown_ = true;
    lws_cancel_service(context_);
 
    listenThread_.join();
@@ -118,59 +122,100 @@ void WsServerConnection::stopServer()
    context_ = nullptr;
    packets_ = {};
    clients_ = {};
-   socketToClientIdMap_ = {};
 }
 
 int WsServerConnection::callback(lws *wsi, int reason, void *in, size_t len)
 {
    switch (reason) {
       case LWS_CALLBACK_EVENT_WAIT_CANCELLED: {
-         std::queue<WsServerDataToSend> packets;
-         {  std::lock_guard<std::recursive_mutex> lock(mutex_);
+         std::queue<DataToSend> packets;
+         {  std::lock_guard<std::mutex> lock(mutex_);
             std::swap(packets, packets_);
          }
          while (!packets.empty()) {
             auto data = std::move(packets.front());
             packets.pop();
 
+            if (data.clientId == kAllClientsId) {
+               for (auto &item : clients_) {
+                  auto &client = item.second;
+                  client.allPackets.insert(std::make_pair(client.queuedCounter, data.packet));
+                  client.queuedCounter += 1;
+                  requestWriteIfNeeded(client);
+               }
+               continue;
+            }
+
             auto clientIt = clients_.find(data.clientId);
             if (clientIt == clients_.end()) {
-               SPDLOG_LOGGER_DEBUG(logger_, "send failed, client {} already disconnected"
-                  , bs::toHex(data.clientId));
+               SPDLOG_LOGGER_DEBUG(logger_, "send failed, client {} already disconnected", bs::toHex(data.clientId));
                continue;
             }
             auto &client = clientIt->second;
-            client.packets.push(std::move(data.packet));
-            lws_callback_on_writable(client.wsi);
+            client.allPackets.insert(std::make_pair(client.queuedCounter, data.packet));
+            client.queuedCounter += 1;
+            requestWriteIfNeeded(client);
          }
-         break;
+         return 0;
       }
 
       case LWS_CALLBACK_ESTABLISHED: {
-         auto clientId = nextClientId();
-         auto &client = clients_[clientId];
-         client.wsi = wsi;
-         client.clientId = clientId;
-
-         socketToClientIdMap_[wsi] = clientId;
-         SPDLOG_LOGGER_DEBUG(logger_, "new client connected: {}", bs::toHex(clientId));
-         break;
+         auto &connection = connections_[wsi];
+         auto socket = lws_get_socket_fd(wsi);
+         connection.ipAddr = bs::network::peerAddressString(socket);
+         SPDLOG_LOGGER_DEBUG(logger_, "wsi connected: {}, ip address: {}"
+            , static_cast<void*>(wsi), connection.ipAddr);
+         return 0;
       }
 
       case LWS_CALLBACK_CLOSED: {
-         auto clientId = socketToClientIdMap_.at(wsi);
-         SPDLOG_LOGGER_DEBUG(logger_, "client disconnected: {}", bs::toHex(clientId));
-         socketToClientIdMap_.erase(wsi);
-         size_t count = clients_.erase(clientId);
-         assert(count == 1);
-         break;
+         SPDLOG_LOGGER_DEBUG(logger_, "wsi disconnected: {}", static_cast<void*>(wsi));
+         auto connectionIt = connections_.find(wsi);
+         assert(connectionIt != connections_.end());
+         auto &connection = connectionIt->second;
+         switch (connection.state) {
+            case State::Connected:
+            case State::SendingHandshakeResumed: {
+               const auto &clientId = connection.clientId;
+               auto &client = clients_.at(connection.clientId);
+               SPDLOG_LOGGER_DEBUG(logger_, "connection closed unexpectedly, clientId: {}", bs::toHex(connection.clientId));
+               client.wsi = nullptr;
+               scheduleCallback(kClientTimeout + std::chrono::seconds(1), [this, clientId] {
+                  auto clientIt = clients_.find(clientId);
+                  if (clientIt == clients_.end()) {
+                     return;
+                  }
+                  auto &client = clientIt->second;
+                  if (client.wsi == nullptr && std::chrono::steady_clock::now() - client.lastResumed > kClientTimeout) {
+                     SPDLOG_LOGGER_ERROR(logger_, "connection removed by timeout");
+                     listener_->OnClientDisconnected(clientId);
+                     listener_->onClientError(clientId, ServerConnectionListener::Timeout, {});
+                     clients_.erase(clientIt);
+                  }
+               });
+               break;
+            }
+            case State::SendingHandshakeNew:
+            case State::SendingHandshakeNotFound:
+            case State::WaitHandshake:
+            case State::Closed: {
+               // Nothing to do
+               break;
+            }
+         }
+         connections_.erase(connectionIt);
+         return 0;
       }
 
       case LWS_CALLBACK_RECEIVE: {
-         auto clientId = socketToClientIdMap_.at(wsi);
-         auto &client = clients_.at(clientId);
+         auto &connection = connections_.at(wsi);
+
          auto ptr = static_cast<const char*>(in);
-         client.currFragment.insert(client.currFragment.end(), ptr, ptr + len);
+         connection.currFragment.insert(connection.currFragment.end(), ptr, ptr + len);
+         if (connection.currFragment.size() > params_.maximumPacketSize) {
+            SPDLOG_LOGGER_ERROR(logger_, "maximum packet size reached");
+            return -1;
+         }
          if (lws_remaining_packet_payload(wsi) > 0) {
             return 0;
          }
@@ -178,40 +223,186 @@ int WsServerConnection::callback(lws *wsi, int reason, void *in, size_t len)
             SPDLOG_LOGGER_ERROR(logger_, "unexpected fragment");
             return -1;
          }
-         transport_->processIncomingData(client.currFragment, clientId, -1);
-         client.currFragment.clear();
+
+         auto packet = WsPacket::parsePacket(connection.currFragment, logger_);
+         connection.currFragment.clear();
+
+         switch (connection.state) {
+            case State::Connected: {
+               auto &client = clients_.at(connection.clientId);
+               switch (packet.type) {
+                  case WsPacket::Type::Data: {
+                     client.recvCounter += 1;
+                     listener_->OnDataFromClient(connection.clientId, packet.payload);
+                     break;
+                  }
+                  case WsPacket::Type::Ack: {
+                     if (!processSentAck(client, packet.recvCounter)) {
+                        SPDLOG_LOGGER_ERROR(logger_, "invalid ack");
+                        return -1;
+                     }
+                     break;
+                  }
+                  case WsPacket::Type::Close: {
+                     cookieToClientIdMap_.erase(client.cookie);
+                     clients_.erase(connection.clientId);
+                     connection.state = State::Closed;
+                     listener_->OnClientDisconnected(connection.clientId);
+                     return -1;
+                  }
+                  default: {
+                     SPDLOG_LOGGER_ERROR(logger_, "unexpected packet");
+                     return -1;
+                  }
+               }
+               requestWriteIfNeeded(client);
+               return 0;
+            }
+            case State::WaitHandshake: {
+               switch (packet.type) {
+                  case WsPacket::Type::RequestNew: {
+                     connection.state = State::SendingHandshakeNew;
+                     lws_callback_on_writable(wsi);
+                     return 0;
+                  }
+                  case WsPacket::Type::RequestResumed: {
+                     auto cookieIt = cookieToClientIdMap_.find(packet.payload);
+                     if (cookieIt == cookieToClientIdMap_.end()) {
+                        connection.state = State::SendingHandshakeNotFound;
+                        lws_callback_on_writable(wsi);
+                        SPDLOG_LOGGER_ERROR(logger_, "resume cookie not found");
+                        return 0;
+                     }
+                     const auto &clientId = cookieIt->second;
+                     auto &client = clients_.at(clientId);
+                     if (!processSentAck(client, packet.recvCounter)) {
+                        SPDLOG_LOGGER_ERROR(logger_, "resuming connection failed");
+                        return -1;
+                     }
+                     if (client.wsi != nullptr) {
+                        auto &oldConnection = connections_.at(client.wsi);
+                        oldConnection.state = State::Closed;
+                        lws_callback_on_writable(client.wsi);
+                     }
+                     connection.state = State::SendingHandshakeResumed;
+                     connection.clientId = clientId;
+                     client.wsi = wsi;
+                     client.lastResumed = std::chrono::steady_clock::now();
+                     lws_callback_on_writable(wsi);
+                     return 0;
+                  }
+                  default: {
+                     SPDLOG_LOGGER_ERROR(logger_, "unexpected packet");
+                     return -1;
+                  }
+               }
+            }
+            case State::SendingHandshakeNotFound:
+            case State::SendingHandshakeResumed:
+            case State::SendingHandshakeNew: {
+               SPDLOG_LOGGER_ERROR(logger_, "unexpected packet");
+               return -1;
+            }
+            case State::Closed: {
+               return -1;
+            }
+         }
          break;
       }
 
       case LWS_CALLBACK_SERVER_WRITEABLE: {
-         auto clientId = socketToClientIdMap_.at(wsi);
-         auto &client = clients_.at(clientId);
-         if (client.packets.empty()) {
-            return 0;
-         }
+         auto &connection = connections_.at(wsi);
 
-         auto packet = std::move(client.packets.front());
-         client.packets.pop();
+         switch (connection.state) {
+            case State::Connected: {
+               auto &client = clients_.at(connection.clientId);
 
-         int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
-         if (rc == -1) {
-            SPDLOG_LOGGER_ERROR(logger_, "write failed");
-            return -1;
+               if (client.recvCounter != client.recvAckCounter) {
+                  auto packet = WsPacket::ack(client.recvCounter);
+                  int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
+                  if (rc != static_cast<int>(packet.getSize())) {
+                      SPDLOG_LOGGER_ERROR(logger_, "write failed");
+                      return -1;
+                  }
+                  client.recvAckCounter = client.recvCounter;
+               } else if (client.sentCounter != client.queuedCounter) {
+                  auto &packet = client.allPackets.at(client.sentCounter);
+                  int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
+                  if (rc == -1) {
+                     SPDLOG_LOGGER_ERROR(logger_, "write failed");
+                     return -1;
+                  }
+                  if (rc != static_cast<int>(packet.getSize())) {
+                      SPDLOG_LOGGER_ERROR(logger_, "write truncated");
+                      return -1;
+                  }
+                  client.sentCounter += 1;
+               }
+               requestWriteIfNeeded(client);
+               return 0;
+            }
+            case State::WaitHandshake: {
+               return 0;
+            }
+            case State::SendingHandshakeNotFound: {
+               auto packet = WsPacket::responseUnknown();
+               lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
+               connection.state = State::Closed;
+               return -1;
+            }
+            case State::SendingHandshakeResumed: {
+               auto &client = clients_.at(connection.clientId);
+               auto packet = WsPacket::responseResumed(client.recvCounter);
+               int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
+               if (rc == -1) {
+                  SPDLOG_LOGGER_ERROR(logger_, "write failed");
+                  return -1;
+               }
+               connection.state = State::Connected;
+               lws_callback_on_writable(wsi);
+               return 0;
+            }
+            case State::SendingHandshakeNew: {
+               auto cookie = CryptoPRNG::generateRandom(32).toBinStr();
+               auto packet = WsPacket::responseNew(cookie);
+               int rc = lws_write(wsi, packet.getPtr(), packet.getSize(), LWS_WRITE_BINARY);
+               if (rc == -1) {
+                  SPDLOG_LOGGER_ERROR(logger_, "write failed");
+                  return -1;
+               }
+               auto clientId = nextClientId();
+               connection.state = State::Connected;
+               cookieToClientIdMap_[cookie] = clientId;
+               auto &client = clients_[clientId];
+               client.wsi = wsi;
+               connection.clientId = clientId;
+               ServerConnectionListener::Details details;
+               details[ServerConnectionListener::Detail::IpAddr] = connection.ipAddr;
+               SPDLOG_LOGGER_DEBUG(logger_, "new session started for client {}", clientId);
+               listener_->OnClientConnected(clientId, details);
+               lws_callback_on_writable(wsi);
+               return 0;
+            }
+            case State::Closed: {
+               return -1;
+            }
          }
-         if (rc != static_cast<int>(packet.getSize())) {
-             SPDLOG_LOGGER_ERROR(logger_, "write truncated");
-             return -1;
-         }
-
-         if (!client.packets.empty()) {
-            lws_callback_on_writable(client.wsi);
-         }
-
-         break;
+      }
+      default: {
+         return 0;
       }
    }
 
+   assert(false);
    return 0;
+}
+
+void WsServerConnection::timerCallback(lws_sorted_usec_list *list)
+{
+   auto data = static_cast<WsServerTimer*>(list);
+   data->callback();
+   auto count = data->owner_->timers_.erase(data->timerId);
+   assert(count == 1);
 }
 
 std::string WsServerConnection::nextClientId()
@@ -221,26 +412,79 @@ std::string WsServerConnection::nextClientId()
    return std::string(ptr, ptr + sizeof(nextClientId_));
 }
 
-std::thread::id WsServerConnection::listenThreadId() const
+bool WsServerConnection::done() const
 {
-   return listenThread_.get_id();
+   if (!shuttingDown_) {
+      return false;
+   }
+   {  std::lock_guard<std::mutex> lock(mutex_);
+      if (!packets_.empty()) {
+         return false;
+      }
+   }
+   for (const auto &connectionItem : connections_) {
+      const auto &connection = connectionItem.second;
+      if (connection.state == State::Connected) {
+         const auto &client = clients_.at(connection.clientId);
+         if (client.sentCounter != client.queuedCounter) {
+            return false;
+         }
+      }
+   }
+   return true;
 }
 
-std::string WsServerConnection::GetClientInfo(const std::string &clientId) const
+bool WsServerConnection::writeNeeded(const ClientData &client) const
 {
-   return {};
+   if (client.wsi == nullptr) {
+      return false;
+   }
+   return client.sentCounter != client.queuedCounter || client.recvCounter != client.recvAckCounter;
+}
+
+void WsServerConnection::requestWriteIfNeeded(const ClientData &client)
+{
+   if (writeNeeded(client)) {
+      lws_callback_on_writable(client.wsi);
+   }
+}
+
+bool WsServerConnection::processSentAck(WsServerConnection::ClientData &client, uint64_t sentAckCounter)
+{
+   if (sentAckCounter < client.sentAckCounter || sentAckCounter > client.sentCounter) {
+      SPDLOG_LOGGER_ERROR(logger_, "invalid ack value from client");
+      return false;
+   }
+
+   while (client.sentAckCounter < sentAckCounter) {
+      size_t count = client.allPackets.erase(client.sentAckCounter);
+      assert(count == 1);
+      client.sentAckCounter += 1;
+   }
+
+   return true;
+}
+
+void WsServerConnection::scheduleCallback(std::chrono::milliseconds timeout, WsServerConnection::TimerCallback callback)
+{
+   auto timerId = nextTimerId_;
+   nextTimerId_ += 1;
+
+   auto timer = std::make_unique<WsServerTimer>();
+   std::memset(static_cast<lws_sorted_usec_list_t*>(timer.get()), 0, sizeof(lws_sorted_usec_list_t));
+   timer->owner_ = this;
+   timer->timerId = timerId;
+   timer->callback = std::move(callback);
+
+   lws_sul_schedule(context_, 0, timer.get(), timerCallback, static_cast<lws_usec_t>(timeout / std::chrono::microseconds(1)));
+
+   timers_.insert(std::make_pair(timerId, std::move(timer)));
 }
 
 bool WsServerConnection::SendDataToClient(const std::string &clientId, const std::string &data)
 {
-   return transport_->sendData(clientId, data);
-}
-
-bool WsServerConnection::sendData(const std::string &clientId, const std::string &data)
-{
-   WsServerDataToSend toSend{ clientId, WsPacket(data) };
-   {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
+   DataToSend toSend{clientId, WsPacket::data(data)};
+   {  std::lock_guard<std::mutex> lock(mutex_);
       packets_.push(std::move(toSend));
    }
    lws_cancel_service(context_);
@@ -248,16 +492,8 @@ bool WsServerConnection::sendData(const std::string &clientId, const std::string
 }
 
 bool WsServerConnection::SendDataToAllClients(const std::string &data)
-{  // In encrypted environments data can't be broadcasted - it needs to be first
-   // encrypted by per-connection keys (which are different for each client).
-   // So we use multicast here.
-   size_t cntClients = clients_.size();
-   for (const auto &item : clients_) {
-      if (SendDataToClient(item.first, data)) {
-         cntClients--;
-      }
-   }
-   return (cntClients == 0);
+{
+   return SendDataToClient(kAllClientsId, data);
 }
 
 int WsServerConnection::callbackHelper(lws *wsi, int reason, void *in, size_t len)

--- a/BlocksettleNetworkingLib/WsServerConnection.cpp
+++ b/BlocksettleNetworkingLib/WsServerConnection.cpp
@@ -79,6 +79,7 @@ bool WsServerConnection::BindConnection(const std::string& host , const std::str
    info.options = LWS_SERVER_OPTION_VALIDATE_UTF8 | LWS_SERVER_OPTION_DISABLE_IPV6;
    info.user = this;
 
+   // Context creation will return nullptr if port binding failed
    context_ = lws_create_context(&info);
    if (context_ == nullptr) {
       SPDLOG_LOGGER_ERROR(logger_, "context create failed");

--- a/BlocksettleNetworkingLib/WsServerConnection.cpp
+++ b/BlocksettleNetworkingLib/WsServerConnection.cpp
@@ -109,7 +109,8 @@ void WsServerConnection::stopServer()
    }
 
    DataToSend toSend{kAllClientsId, WsPacket::close()};
-   {  std::lock_guard<std::mutex> lock(mutex_);
+   {
+      std::lock_guard<std::mutex> lock(mutex_);
       packets_.push(std::move(toSend));
    }
    shuttingDown_ = true;
@@ -129,7 +130,8 @@ int WsServerConnection::callback(lws *wsi, int reason, void *in, size_t len)
    switch (reason) {
       case LWS_CALLBACK_EVENT_WAIT_CANCELLED: {
          std::queue<DataToSend> packets;
-         {  std::lock_guard<std::mutex> lock(mutex_);
+         {
+            std::lock_guard<std::mutex> lock(mutex_);
             std::swap(packets, packets_);
          }
          while (!packets.empty()) {
@@ -417,7 +419,8 @@ bool WsServerConnection::done() const
    if (!shuttingDown_) {
       return false;
    }
-   {  std::lock_guard<std::mutex> lock(mutex_);
+   {
+      std::lock_guard<std::mutex> lock(mutex_);
       if (!packets_.empty()) {
          return false;
       }
@@ -484,7 +487,8 @@ void WsServerConnection::scheduleCallback(std::chrono::milliseconds timeout, WsS
 bool WsServerConnection::SendDataToClient(const std::string &clientId, const std::string &data)
 {
    DataToSend toSend{clientId, WsPacket::data(data)};
-   {  std::lock_guard<std::mutex> lock(mutex_);
+   {
+      std::lock_guard<std::mutex> lock(mutex_);
       packets_.push(std::move(toSend));
    }
    lws_cancel_service(context_);

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -134,6 +134,7 @@ private:
    uint64_t nextClientId_{};
    std::map<uint64_t, std::unique_ptr<WsServerTimer>> timers_;
    uint64_t nextTimerId_{};
+   bool shuttingDownReceived_{};
 
 };
 

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -15,28 +15,36 @@
 #include "WsConnection.h"
 
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <queue>
+#include <set>
 #include <thread>
-#include <map>
 
 namespace spdlog {
    class logger;
 }
-namespace bs{
+
+struct WsServerTimer;
+struct lws;
+struct lws_context;
+struct lws_sorted_usec_list;
+
+namespace bs {
    namespace network {
-      class TransportServer;
+      struct WsPacket;
    }
 }
-struct lws_context;
-struct lws;
 
+struct WsServerConnectionParams
+{
+   size_t maximumPacketSize{bs::network::ws::kDefaultMaximumWsPacketSize};
+};
 
 class WsServerConnection : public ServerConnection
 {
 public:
-   WsServerConnection(const std::shared_ptr<spdlog::logger> &
-      , const std::shared_ptr<bs::network::TransportServer> &);
+   WsServerConnection(const std::shared_ptr<spdlog::logger>& logger, WsServerConnectionParams params);
    ~WsServerConnection() override;
 
    WsServerConnection(const WsServerConnection&) = delete;
@@ -47,56 +55,86 @@ public:
    bool BindConnection(const std::string& host, const std::string& port
       , ServerConnectionListener* listener) override;
 
-   std::string GetClientInfo(const std::string &clientId) const override;
-
    bool SendDataToClient(const std::string& clientId, const std::string& data) override;
    bool SendDataToAllClients(const std::string&) override;
 
    static int callbackHelper(struct lws *wsi, int reason, void *in, size_t len);
 
+   using TimerCallback = std::function<void()>;
+
 private:
-   std::thread::id listenThreadId() const;
+   enum class State
+   {
+      WaitHandshake,
+      SendingHandshakeNew,
+      SendingHandshakeResumed,
+      SendingHandshakeNotFound,
+      Connected,
+      Closed,
+   };
+
+   struct DataToSend
+   {
+      std::string clientId;
+      bs::network::WsRawPacket packet;
+   };
+
+   struct ConnectionData
+   {
+      std::string currFragment;
+      State state{State::WaitHandshake};
+      std::string clientId; // only for State::Connected and State::SendingHandshakeResumed
+      std::string ipAddr;
+   };
+
+   struct ClientData
+   {
+      std::map<uint64_t, bs::network::WsRawPacket> allPackets;
+      std::string cookie;
+      lws *wsi{};
+      uint64_t sentCounter{};
+      uint64_t sentAckCounter{};
+      uint64_t queuedCounter{};
+      uint64_t recvCounter{};
+      uint64_t recvAckCounter{};
+      std::chrono::steady_clock::time_point lastResumed{};
+   };
 
    void listenFunction();
 
    void stopServer();
 
-   int callback(struct lws *wsi, int reason, void *in, size_t len);
+   int callback(lws *wsi, int reason, void *in, size_t len);
 
+   static void timerCallback(lws_sorted_usec_list *list);
+
+   // Methods accessible from listener thread only
    std::string nextClientId();
-
-   bool sendData(const std::string& clientId, const std::string& data);
-
-private:
-   struct WsServerDataToSend
-   {
-      std::string clientId;
-      bs::network::WsPacket packet;
-   };
-
-   struct WsServerClientData
-   {
-      std::string clientId;
-      lws *wsi{};
-      std::queue<bs::network::WsPacket> packets;
-      std::string currFragment;
-   };
+   bool done() const;
+   bool writeNeeded(const ClientData &client) const;
+   void requestWriteIfNeeded(const ClientData &client);
+   bool processSentAck(ClientData &client, uint64_t sentAckCounter);
+   void scheduleCallback(std::chrono::milliseconds timeout, TimerCallback callback);
 
    std::shared_ptr<spdlog::logger>  logger_;
-   std::shared_ptr<bs::network::TransportServer>   transport_;
+   const WsServerConnectionParams params_;
 
    std::thread listenThread_;
    ServerConnectionListener *listener_{};
-   std::atomic_bool stopped_{};
+   std::atomic_bool shuttingDown_{};
    lws_context *context_{};
 
-   std::recursive_mutex mutex_;
-   std::queue<WsServerDataToSend> packets_;
+   mutable std::mutex mutex_;
+   std::queue<DataToSend> packets_;
 
    // Fields accessible from listener thread only
-   std::map<std::string, WsServerClientData> clients_;
-   std::map<lws*, std::string> socketToClientIdMap_;
+   std::map<lws*, ConnectionData> connections_;
+   std::map<std::string, ClientData> clients_;
+   std::map<std::string, std::string> cookieToClientIdMap_;
    uint64_t nextClientId_{};
+   std::map<uint64_t, std::unique_ptr<WsServerTimer>> timers_;
+   uint64_t nextTimerId_{};
+
 };
 
 #endif // WS_SERVER_CONNECTION_H

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -39,6 +39,9 @@ namespace bs {
 struct WsServerConnectionParams
 {
    size_t maximumPacketSize{bs::network::ws::kDefaultMaximumWsPacketSize};
+
+   // For tests only
+   std::function<std::string()> testCookieGenerator;
 };
 
 class WsServerConnection : public ServerConnection

--- a/BlocksettleNetworkingLib/ZmqDataConnection.cpp
+++ b/BlocksettleNetworkingLib/ZmqDataConnection.cpp
@@ -12,32 +12,22 @@
 
 #include "FastLock.h"
 #include "MessageHolder.h"
-#include "ThreadName.h"
-#include "Transport.h"
 #include "ZmqHelperFunctions.h"
 
 #include <zmq.h>
 #include <spdlog/spdlog.h>
 
-
-ZmqDataConnection::ZmqDataConnection(const std::shared_ptr<spdlog::logger>& logger
-   , const std::shared_ptr<bs::network::TransportClient> &tr, bool useMonitor)
+ZmqDataConnection::ZmqDataConnection(const std::shared_ptr<spdlog::logger>& logger, bool useMonitor)
    : logger_(logger)
-   , transport_(tr)
    , useMonitor_(useMonitor)
    , dataSocket_(ZmqContext::CreateNullSocket())
    , monSocket_(ZmqContext::CreateNullSocket())
    , threadMasterSocket_(ZmqContext::CreateNullSocket())
    , threadSlaveSocket_(ZmqContext::CreateNullSocket())
+   , isConnected_(false)
 {
    assert(logger_);
    continueExecution_ = std::make_shared<bool>(false);
-
-   if (transport_) {
-      transport_->setSendCb([this](const std::string &d) { return sendRawData(d); });
-      transport_->setNotifyDataCb([this](const std::string &d) { notifyOnData(d); });
-      transport_->setSocketErrorCb([this](DataConnectionListener::DataConnectionError e) { onError(e); });
-   }
 }
 
 ZmqDataConnection::~ZmqDataConnection() noexcept
@@ -70,10 +60,6 @@ bool ZmqDataConnection::openConnection(const std::string& host
 {
    assert(context_ != nullptr);
    assert(listener != nullptr);
-
-   if (transport_) {
-      transport_->openConnection(host, port);
-   }
 
    if (isActive()) {
       if (logger_) {
@@ -188,20 +174,6 @@ bool ZmqDataConnection::openConnection(const std::string& host
       return false;
    }
 
-   int bufSz = 0;
-   size_t bufSzSize = sizeof(bufSz);
-   result = zmq_getsockopt(tempDataSocket.get(), ZMQ_RCVBUF, &bufSz, &bufSzSize);
-   if (result != 0) {
-      if (logger_) {
-         logger_->error("[{}] failed to get RCVBUF size {}", __func__
-            , tempConnectionName);
-      }
-      return false;
-   }
-   if (bufSz > 0) {
-      bufSizeLimit_ = bufSz;
-   }
-
    // get socket id
    result = zmq_getsockopt(tempDataSocket.get(), ZMQ_IDENTITY, buf, &buf_size);
    if (result != 0) {
@@ -273,77 +245,8 @@ bool ZmqDataConnection::ConfigureDataSocket(const ZmqContext::sock_ptr& socket)
    return true;
 }
 
-void ZmqDataConnection::onError(DataConnectionListener::DataConnectionError errorCode)
-{
-   if (transport_ && (errorCode == DataConnectionListener::NoError)) {  // connection signal from transport
-      onConnected();
-      return;
-   }
-
-   assert(std::this_thread::get_id() == listenThread_.get_id());
-
-   // Notify about error only once
-   if (!isConnected_ && (errorCode != DataConnectionListener::ConnectionTimeout)) {
-      return;
-   }
-
-/*   if (errorCode == DataConnectionListener::SerializationFailed) {
-      if (logger_) {
-         logger_->warn("[ZmqDataConnection::onError] deser error - non fatal, "
-            "just skip corrupted data");
-      }
-      return;
-   }*/
-
-   if (isConnected_) {
-      onDisconnected();
-   }
-
-   if (logger_) {
-      logger_->error("[ZmqDataConnection::onError] error {}", (int)errorCode);
-   }
-   isConnected_ = false;
-   notifyOnError(errorCode);
-}
-
-void ZmqDataConnection::onConnected()
-{
-   assert(std::this_thread::get_id() == listenThread_.get_id());
-   assert(!isConnected_);
-
-   isConnected_ = true;
-   if (transport_) {
-      transport_->socketConnected();
-   }
-   notifyOnConnected();
-}
-
-void ZmqDataConnection::onDisconnected()
-{
-   assert(std::this_thread::get_id() == listenThread_.get_id());
-   assert(isConnected_);
-   isConnected_ = false;
-   if (transport_) {
-      transport_->socketDisconnected();
-   }
-   notifyOnDisconnected();
-}
-
-bool ZmqDataConnection::sendData(const std::string &data)
-{
-   if (transport_) {
-      return transport_->sendData(data);
-   }
-   else {
-      return sendRawData(data);
-   }
-}
-
 void ZmqDataConnection::listenFunction()
 {
-   if (transport_) {
-      bs::setCurrentThreadName(transport_->listenThreadName());
-   }
    zmq_pollitem_t  poll_items[3];
    memset(&poll_items, 0, sizeof(poll_items));
 
@@ -361,34 +264,15 @@ void ZmqDataConnection::listenFunction()
    int result;
 
    auto executionFlag = continueExecution_;
-   if (transport_) {
-      transport_->startConnection();
-   }
-   bool transportConnected = false;
 
    while (*executionFlag) {
-      result = zmq_poll(poll_items, monSocket_ ? 3 : 2
-         , transport_ ? transport_->pollTimeoutMS() : -1);
+      result = zmq_poll(poll_items, monSocket_ ? 3 : 2, -1);
       if (result == -1) {
          if (logger_) {
             logger_->error("[{}] poll failed for {} : {}", __func__
                , connectionName_, zmq_strerror(zmq_errno()));
          }
          break;
-      }
-
-      if (transport_) {
-         if (transport_->connectTimedOut()) {
-            if (transport_->handshakeTimedOut()) {
-               SPDLOG_LOGGER_ERROR(logger_, "ZMQ handshake is timed out");
-               onError(DataConnectionListener::HandshakeFailed);
-            } else {
-               SPDLOG_LOGGER_ERROR(logger_, "ZMQ transport connection is timed out");
-               onError(DataConnectionListener::ConnectionTimeout);
-            }
-            break;
-         }
-         transport_->triggerHeartbeatCheck();
       }
 
       if (poll_items[ZmqDataConnection::ControlSocketIndex].revents & ZMQ_POLLIN) {
@@ -432,9 +316,6 @@ void ZmqDataConnection::listenFunction()
             }
          }
          else if (command_code == ZmqDataConnection::CommandStop) {
-            if (transport_) {
-               transport_->sendDisconnect();
-            }
             break;
          } else {
             if (logger_) {
@@ -462,22 +343,16 @@ void ZmqDataConnection::listenFunction()
          // NOTE: for ZMQ based connections this event might better suited than ZMQ_EVENT_CONNECTED
          // but they always came in pairs
          //case ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
-            if (transport_) {
-               if (!transportConnected) {
-                  transport_->startHandshake();
-                  transportConnected = true;
-               }
-            }
-            else {
-               if (!isConnected_) {
-                  onConnected();
-               }
+            if (!isConnected_) {
+               notifyOnConnected();
+               isConnected_ = true;
             }
             break;
 
          case ZMQ_EVENT_DISCONNECTED:
             if (isConnected_) {
-               onDisconnected();
+               notifyOnDisconnected();
+               isConnected_ = false;
             }
             break;
          default:
@@ -488,9 +363,6 @@ void ZmqDataConnection::listenFunction()
 
    if (*executionFlag) {
       zmq_socket_monitor(dataSocket_.get(), nullptr, ZMQ_EVENT_ALL);
-   }
-   if (isConnected_) {
-      onDisconnected();
    }
 }
 
@@ -511,45 +383,20 @@ bool ZmqDataConnection::recvData()
       return false;
    }
 
-   {
-      int result = zmq_msg_recv(&data, dataSocket_.get(), ZMQ_DONTWAIT);
-      if (result == -1) {
-         if (logger_) {
-            logger_->error("[{}] {} failed to recv data frame from stream: {}"
-               , __func__, connectionName_, zmq_strerror(zmq_errno()));
-         }
-         return false;
+   result = zmq_msg_recv(&data, dataSocket_.get(), ZMQ_DONTWAIT);
+   if (result == -1) {
+      if (logger_) {
+         logger_->error("[{}] {} failed to recv data frame from stream: {}"
+            , __func__, connectionName_, zmq_strerror(zmq_errno()));
       }
+      return false;
    }
 
-   if (transport_) {
-      if (data.GetSize() == 0) {
-         // nothing to do - connection is handled by monitoring socket
-      }
-      else {
-         if (data.GetSize() == bufSizeLimit_) {    // Send buffer split, which is undetected by data.IsLast()
-            accumulBuf_.append(data.ToString());
-            return true;
-         }
-         else {
-            if (accumulBuf_.empty()) {
-               transport_->onRawDataReceived(data.ToString());
-            }
-            else {
-               accumulBuf_.append(data.ToString());
-               transport_->onRawDataReceived(accumulBuf_);
-               accumulBuf_.clear();
-            }
-         }
-      }
-   }
-   else {
-      if (data.GetSize() == 0) {
-         //we are either connected or disconncted
-         zeroFrameReceived();
-      } else {
-         onRawDataReceived(data.ToString());
-      }
+   if (data.GetSize() == 0) {
+      //we are either connected or disconncted
+      zeroFrameReceived();
+   } else {
+      onRawDataReceived(data.ToString());
    }
 
    return true;
@@ -561,12 +408,14 @@ void ZmqDataConnection::zeroFrameReceived()
       if (logger_) {
          SPDLOG_LOGGER_TRACE(logger_, "{} received 0 frame. Disconnected.", connectionName_);
       }
-      onDisconnected();
+      isConnected_ = false;
+      notifyOnDisconnected();
    } else {
       if (logger_) {
          SPDLOG_LOGGER_TRACE(logger_, "{} received 0 frame. Connected.", connectionName_);
       }
-      onConnected();
+      isConnected_ = true;
+      notifyOnConnected();
    }
 }
 
@@ -574,10 +423,6 @@ bool ZmqDataConnection::closeConnection()
 {
    if (!isActive()) {
       return true;
-   }
-
-   if (transport_) {
-      transport_->closeConnection();
    }
 
    if (std::this_thread::get_id() == listenThread_.get_id()) {
@@ -607,7 +452,7 @@ bool ZmqDataConnection::sendRawData(const std::string& rawData)
 {
    if (!isActive()) {
       if (logger_) {
-         logger_->error("[ZmqDataConnection::sendRawData] could not send - not active");
+         logger_->error("[{}] could not send. not connected", __func__);
       }
       return false;
    }
@@ -622,8 +467,8 @@ bool ZmqDataConnection::sendRawData(const std::string& rawData)
    int result = zmq_send(threadMasterSocket_.get(), static_cast<void*>(&command), sizeof(command), 0);
    if (result == -1) {
       if (logger_) {
-         logger_->error("[ZmqDataConnection::sendRawData] failed to send command"
-            " for {} : {}", connectionName_, zmq_strerror(zmq_errno()));
+         logger_->error("[{}] failed to send command for {} : {}", __func__
+            , connectionName_, zmq_strerror(zmq_errno()));
       }
       return false;
    }

--- a/BlocksettleNetworkingLib/ZmqHelperFunctions.cpp
+++ b/BlocksettleNetworkingLib/ZmqHelperFunctions.cpp
@@ -84,6 +84,6 @@ std::string bs::network::peerAddressString(int socket)
    if (rc == 0) {
       return inet_ntoa(peerInfo.sin_addr);
    } else {
-      return "Not detected";
+      return "";
    }
 }

--- a/BlocksettleNetworkingLib/ZmqServerConnection.cpp
+++ b/BlocksettleNetworkingLib/ZmqServerConnection.cpp
@@ -371,7 +371,7 @@ void ZmqServerConnection::onPeriodicCheck()
 
 void ZmqServerConnection::SendDataToDataSocket()
 {
-   std::deque<DataToSend> pendingData;
+   decltype(dataQueue_) pendingData;
 
    {
       FastLock locker{dataQueueLock_};

--- a/BlocksettleNetworkingLib/ZmqServerConnection.cpp
+++ b/BlocksettleNetworkingLib/ZmqServerConnection.cpp
@@ -31,7 +31,6 @@ ZmqServerConnection::ZmqServerConnection(
    : logger_(logger)
    , context_(context)
    , dataSocket_(ZmqContext::CreateNullSocket())
-   , monSocket_(ZmqContext::CreateNullSocket())
    , threadMasterSocket_(ZmqContext::CreateNullSocket())
    , threadSlaveSocket_(ZmqContext::CreateNullSocket())
    , threadName_("ZmqSrv")
@@ -90,31 +89,6 @@ bool ZmqServerConnection::BindConnection(const std::string& host , const std::st
       return false;
    }
 
-   ZmqContext::sock_ptr tempMonSocket = context_->CreateMonitorSocket();
-   if (tempMonSocket == nullptr) {
-      logger_->error("[{}] failed to open monitor socket {}", __func__
-         , tempConnectionName);
-      return false;
-   }
-
-   int lingerPeriod = 0;
-   int result = zmq_setsockopt(tempMonSocket.get(), ZMQ_LINGER, &lingerPeriod, sizeof(lingerPeriod));
-   if (result != 0) {
-      logger_->error("[{}] failed to config monitor socket on {}", __func__
-         , tempConnectionName);
-      return false;
-   }
-
-   monitorConnectionName_ = "inproc://monitor-" + tempConnectionName;
-
-   result = zmq_socket_monitor(tempDataSocket.get(), monitorConnectionName_.c_str(),
-      ZMQ_EVENT_ALL);
-   if (result != 0) {
-      logger_->error("[{}] failed to create monitor {}", __func__
-         , tempConnectionName);
-      return false;
-   }
-
    for (const std::string &fromAddress : fromAddresses_) {
       // ZMQ_TCP_ACCEPT_FILTER is deprecated in favor of ZAP API.
       // But let's use it for now because our future ZMQ usage is not yet clear.
@@ -125,13 +99,6 @@ bool ZmqServerConnection::BindConnection(const std::string& host , const std::st
       }
    }
 
-   result = zmq_connect(tempMonSocket.get(), monitorConnectionName_.c_str());
-   if (result != 0) {
-      logger_->error("[{}] failed to connect to monitor {}", __func__
-         , tempConnectionName);
-      return false;
-   }
-
    // connect socket to server ( connection state will be changed in listen thread )
    std::string endpoint = ZmqContext::CreateConnectionEndpoint(zmqTransport_, host, port);
    if (endpoint.empty()) {
@@ -139,7 +106,7 @@ bool ZmqServerConnection::BindConnection(const std::string& host , const std::st
       return false;
    }
 
-   result = zmq_bind(tempDataSocket.get(), endpoint.c_str());
+   bool result = zmq_bind(tempDataSocket.get(), endpoint.c_str());
    if (result != 0) {
       logger_->error("[{}] failed to bind socket to {} : {}", __func__
          , endpoint, zmq_strerror(zmq_errno()));
@@ -180,7 +147,6 @@ bool ZmqServerConnection::BindConnection(const std::string& host , const std::st
    // ok, move temp data to members
    connectionName_ = std::move(tempConnectionName);
    dataSocket_ = std::move(tempDataSocket);
-   monSocket_ = std::move(tempMonSocket);
    threadMasterSocket_ = std::move(tempThreadMasterSocket);
    threadSlaveSocket_ = std::move(tempThreadSlaveSocket);
 
@@ -198,7 +164,7 @@ void ZmqServerConnection::listenFunction()
 {
    bs::setCurrentThreadName(threadName_);
 
-   zmq_pollitem_t  poll_items[3];
+   zmq_pollitem_t  poll_items[2];
 
    poll_items[ZmqServerConnection::ControlSocketIndex].socket = threadSlaveSocket_.get();
    poll_items[ZmqServerConnection::ControlSocketIndex].events = ZMQ_POLLIN;
@@ -206,16 +172,13 @@ void ZmqServerConnection::listenFunction()
    poll_items[ZmqServerConnection::DataSocketIndex].socket = dataSocket_.get();
    poll_items[ZmqServerConnection::DataSocketIndex].events = ZMQ_POLLIN;
 
-   poll_items[ZmqServerConnection::MonitorSocketIndex].socket = monSocket_.get();
-   poll_items[ZmqServerConnection::MonitorSocketIndex].events = ZMQ_POLLIN;
-
    logger_->debug("[{}] poll thread started for {}", __func__, connectionName_);
 
    int errorCount = 0;
 
    while (true) {
       int periodMs = std::chrono::duration_cast<std::chrono::milliseconds>(kHearthbeatCheckPeriod).count();
-      int result = zmq_poll(poll_items, 3, periodMs);
+      int result = zmq_poll(poll_items, sizeof(poll_items) / sizeof(poll_items[0]), periodMs);
 
       if (result == -1) {
          errorCount++;
@@ -266,7 +229,6 @@ void ZmqServerConnection::listenFunction()
 
    zmq_socket_monitor(dataSocket_.get(), nullptr, ZMQ_EVENT_ALL);
    dataSocket_ = context_->CreateNullSocket();
-   monSocket_ = context_->CreateNullSocket();
 
    logger_->debug("[{}] poll thread stopped for {}", __func__, connectionName_);
 }

--- a/BlocksettleNetworkingLib/ZmqServerConnection.cpp
+++ b/BlocksettleNetworkingLib/ZmqServerConnection.cpp
@@ -14,7 +14,6 @@
 #include "FastLock.h"
 #include "MessageHolder.h"
 #include "ThreadName.h"
-#include "Transport.h"
 
 #include <spdlog/spdlog.h>
 #include <zmq.h>
@@ -26,10 +25,11 @@ namespace
 
 } // namespace
 
-ZmqServerConnection::ZmqServerConnection(const std::shared_ptr<spdlog::logger> &logger
-   , const std::shared_ptr<ZmqContext> &context
-   , const std::shared_ptr<bs::network::TransportServer> &tr)
-   : logger_(logger), context_(context)
+ZmqServerConnection::ZmqServerConnection(
+   const std::shared_ptr<spdlog::logger>& logger
+   , const std::shared_ptr<ZmqContext>& context)
+   : logger_(logger)
+   , context_(context)
    , dataSocket_(ZmqContext::CreateNullSocket())
    , monSocket_(ZmqContext::CreateNullSocket())
    , threadMasterSocket_(ZmqContext::CreateNullSocket())
@@ -38,10 +38,6 @@ ZmqServerConnection::ZmqServerConnection(const std::shared_ptr<spdlog::logger> &
 {
    assert(logger_ != nullptr);
    assert(context_ != nullptr);
-
-   if (tr) {
-      setTransport(tr);
-   }
 }
 
 ZmqServerConnection::~ZmqServerConnection() noexcept
@@ -55,21 +51,6 @@ ZmqServerConnection::~ZmqServerConnection() noexcept
       // This is not normally needed but good to have to prevent crash in case stopServer fails
       listenThread_.join();
    }
-}
-
-void ZmqServerConnection::setTransport(const std::shared_ptr<bs::network::TransportServer> &tr)
-{
-   transport_ = tr;
-   transport_->setClientErrorCb(
-      [this](const std::string &id, const std::string &err) { notifyListenerOnClientError(id, err); }
-      , [this](const std::string &clientId, ServerConnectionListener::ClientError errorCode
-         , int socket) { notifyListenerOnClientSocketError(clientId, errorCode, socket); });
-   transport_->setDataReceivedCb([this](const std::string &clientId, const std::string &data) {
-      notifyListenerOnData(clientId, data); });
-   transport_->setSendDataCb([this](const std::string &clientId, const std::string &data) {
-      return QueueDataToSend(clientId, data, false); });
-   transport_->setConnectedCb([this](const std::string &clientId) { notifyListenerOnNewConnection(clientId); }
-      , [this](const std::string &clientId) { notifyListenerOnDisconnectedClient(clientId); });
 }
 
 bool ZmqServerConnection::isActive() const
@@ -101,19 +82,6 @@ bool ZmqServerConnection::BindConnection(const std::string& host , const std::st
       logger_->error("[{}] failed to create data socket socket {}", __func__
          , tempConnectionName);
       return false;
-   }
-
-   int bufSz = 0;
-   size_t bufSzSize = sizeof(bufSz);
-   if (zmq_getsockopt(tempDataSocket.get(), ZMQ_RCVBUF, &bufSz, &bufSzSize) != 0) {
-      if (logger_) {
-         logger_->error("[{}] failed to get RCVBUF size {}", __func__
-            , tempConnectionName);
-      }
-      return false;
-   }
-   if (bufSz > 0) {
-      bufSizeLimit_ = bufSz;
    }
 
    if (!ConfigDataSocket(tempDataSocket)) {
@@ -293,48 +261,12 @@ void ZmqServerConnection::listenFunction()
          }
       }
 
-      if (poll_items[ZmqServerConnection::MonitorSocketIndex].revents & ZMQ_POLLIN) {
-         int sock = 0;
-         switch (bs::network::get_monitor_event(monSocket_.get(), &sock)) {
-            case ZMQ_EVENT_ACCEPTED :
-            {
-               std::string cliIP = bs::network::peerAddressString(sock);
-               connectedPeers_.emplace(std::make_pair(sock, cliIP));
-               if (listener_) {
-                  listener_->OnPeerConnected(cliIP);
-               }
-            }
-            break;
-
-            case ZMQ_EVENT_DISCONNECTED :
-            case ZMQ_EVENT_CLOSED :
-            {
-               const auto it = connectedPeers_.find(sock);
-
-               if (it != connectedPeers_.cend()) {
-                  if (listener_) {
-                     listener_->OnPeerDisconnected(it->second);
-                  }
-                  connectedPeers_.erase(it);
-               }
-            }
-            break;
-         }
-      }
-
       onPeriodicCheck();
    }
 
    zmq_socket_monitor(dataSocket_.get(), nullptr, ZMQ_EVENT_ALL);
    dataSocket_ = context_->CreateNullSocket();
    monSocket_ = context_->CreateNullSocket();
-
-   if (listener_) {
-      for (const auto &peer : connectedPeers_) {
-         listener_->OnPeerDisconnected(peer.second);
-      }
-   }
-   connectedPeers_.clear();
 
    logger_->debug("[{}] poll thread stopped for {}", __func__, connectionName_);
 }
@@ -399,12 +331,12 @@ void ZmqServerConnection::notifyListenerOnData(const std::string& clientId, cons
    }
 }
 
-void ZmqServerConnection::notifyListenerOnNewConnection(const std::string& clientId)
+void ZmqServerConnection::notifyListenerOnNewConnection(const std::string& clientId
+   , const ServerConnectionListener::Details &details)
 {
    if (listener_) {
-      listener_->OnClientConnected(clientId);
+      listener_->OnClientConnected(clientId, details);
    }
-   clientInfo_[clientId] = {};
 }
 
 void ZmqServerConnection::notifyListenerOnDisconnectedClient(const std::string& clientId)
@@ -412,31 +344,14 @@ void ZmqServerConnection::notifyListenerOnDisconnectedClient(const std::string& 
    if (listener_) {
       listener_->OnClientDisconnected(clientId);
    }
-   clientInfo_.erase(clientId);
 }
 
-void ZmqServerConnection::notifyListenerOnClientError(const std::string& clientId, const std::string &error)
+void ZmqServerConnection::notifyListenerOnClientError(const std::string &clientId
+   , ServerConnectionListener::ClientError errorCode, const ServerConnectionListener::Details &details)
 {
    if (listener_) {
-      listener_->onClientError(clientId, error);
+      listener_->onClientError(clientId, errorCode, details);
    }
-}
-
-void ZmqServerConnection::notifyListenerOnClientSocketError(const std::string &clientId
-   , ServerConnectionListener::ClientError errorCode, int socket)
-{
-   if (listener_) {
-      listener_->onClientError(clientId, errorCode, socket);
-   }
-}
-
-std::string ZmqServerConnection::GetClientInfo(const std::string &clientId) const
-{
-   const auto &it = clientInfo_.find(clientId);
-   if (it != clientInfo_.end()) {
-      return it->second;
-   }
-   return "Unknown";
 }
 
 bool ZmqServerConnection::QueueDataToSend(const std::string& clientId, const std::string& data
@@ -452,30 +367,26 @@ bool ZmqServerConnection::QueueDataToSend(const std::string& clientId, const std
 
 void ZmqServerConnection::onPeriodicCheck()
 {
-   if (transport_) {
-      transport_->periodicCheck();
-   }
 }
 
 void ZmqServerConnection::SendDataToDataSocket()
 {
-   decltype(dataQueue_) pendingData;
+   std::deque<DataToSend> pendingData;
+
    {
       FastLock locker{dataQueueLock_};
       pendingData.swap(dataQueue_);
    }
 
    for (const auto &dataPacket : pendingData) {
-      int result = zmq_send(dataSocket_.get(), dataPacket.clientId.c_str()
-         , dataPacket.clientId.size(), ZMQ_SNDMORE);
+      int result = zmq_send(dataSocket_.get(), dataPacket.clientId.c_str(), dataPacket.clientId.size(), ZMQ_SNDMORE);
       if (result != dataPacket.clientId.size()) {
          logger_->error("[{}] {} failed to send client id {}", __func__
             , connectionName_, zmq_strerror(zmq_errno()));
          continue;
       }
 
-      result = zmq_send(dataSocket_.get(), dataPacket.data.data(), dataPacket.data.size()
-         , (dataPacket.sendMore ? ZMQ_SNDMORE : 0));
+      result = zmq_send(dataSocket_.get(), dataPacket.data.data(), dataPacket.data.size(), (dataPacket.sendMore ? ZMQ_SNDMORE : 0));
       if (result != dataPacket.data.size()) {
          logger_->error("[{}] {} failed to send data frame {} to {}", __func__
             , connectionName_, zmq_strerror(zmq_errno()), dataPacket.clientId);

--- a/BlocksettleNetworkingLib/ZmqServerConnection.h
+++ b/BlocksettleNetworkingLib/ZmqServerConnection.h
@@ -81,7 +81,6 @@ protected:
 
    // should be accessed only from overloaded ReadFromDataSocket.
    ZmqContext::sock_ptr             dataSocket_;
-   ZmqContext::sock_ptr             monSocket_;
 
    void stopServer();
 
@@ -120,7 +119,6 @@ private:
    std::atomic_flag                 dataQueueLock_ = ATOMIC_FLAG_INIT;
    std::deque<DataToSend>           dataQueue_;
    ZMQTransport                     zmqTransport_ = ZMQTransport::TCPTransport;
-   std::string                      monitorConnectionName_;
    bool        immediate_{ false };
    std::string identity_;
    int sendTimeoutInMs_{ 5000 };

--- a/BlocksettleNetworkingLib/ZmqStreamServerConnection.cpp
+++ b/BlocksettleNetworkingLib/ZmqStreamServerConnection.cpp
@@ -9,18 +9,17 @@
 
 */
 #include "ZmqStreamServerConnection.h"
-#include <zmq.h>
-#include <spdlog/spdlog.h>
+
 #include "ActiveStreamClient.h"
 #include "FastLock.h"
 #include "MessageHolder.h"
-#include "Transport.h"
 
+#include <zmq.h>
+#include <spdlog/spdlog.h>
 
 ZmqStreamServerConnection::ZmqStreamServerConnection(const std::shared_ptr<spdlog::logger>& logger
-   , const std::shared_ptr<ZmqContext>& context
-   , const std::shared_ptr<bs::network::TransportServer> &tr)
-   : ZmqServerConnection(logger, context, tr)
+      , const std::shared_ptr<ZmqContext>& context)
+ : ZmqServerConnection(logger, context)
 {}
 
 ZmqContext::sock_ptr ZmqStreamServerConnection::CreateDataSocket()
@@ -50,35 +49,13 @@ bool ZmqStreamServerConnection::ReadFromDataSocket()
       return false;
    }
 
-   if (transport_) {
-      if (data.GetSize() == 0) {
-         return true;
-      }
-      int socket = zmq_msg_get(&data, ZMQ_SRCFD);
+   if (data.GetSize() == 0) {
+      //we are either connected or disconncted
+      onZeroFrame(id.ToString());
+   } else {
+      onDataFrameReceived(id.ToString(), data.ToString());
+   }
 
-      if (data.GetSize() == bufSizeLimit_) {
-         accumulBuf_.append(data.ToString());
-         return true;
-      }
-      else {
-         if (accumulBuf_.empty()) {
-            transport_->processIncomingData(data.ToString(), id.ToString(), socket);
-         }
-         else {
-            accumulBuf_.append(data.ToString());
-            transport_->processIncomingData(accumulBuf_, id.ToString(), socket);
-            accumulBuf_.clear();
-         }
-      }
-   }
-   else {
-      if (data.GetSize() == 0) {
-         //we are either connected or disconncted
-         onZeroFrame(id.ToString());
-      } else {
-         onDataFrameReceived(id.ToString(), data.ToString());
-      }
-   }
    return true;
 }
 
@@ -107,7 +84,7 @@ void ZmqStreamServerConnection::onZeroFrame(const std::string& clientId)
    }
 
    if (clientConnected) {
-      notifyListenerOnNewConnection(clientId);
+      notifyListenerOnNewConnection(clientId, {});
    } else {
       notifyListenerOnDisconnectedClient(clientId);
    }
@@ -138,42 +115,29 @@ bool ZmqStreamServerConnection::sendRawData(const std::string& clientId, const s
 
 bool ZmqStreamServerConnection::SendDataToClient(const std::string& clientId, const std::string& data)
 {
-   if (transport_) {
-      return transport_->sendData(clientId, data);
+   auto connection = findConnection(clientId);
+   if (connection == nullptr) {
+      logger_->error("[ZmqStreamServerConnection::SendDataToClient] {} send data to closed connection {}"
+         , connectionName_, clientId);
+      return false;
    }
-   else {
-      auto connection = findConnection(clientId);
-      if (connection == nullptr) {
-         logger_->error("[ZmqStreamServerConnection::SendDataToClient] {} send data to closed connection {}"
-            , connectionName_, clientId);
-         return false;
-      }
-      return connection->send(data);
-   }
+
+   const bool result = connection->send(data);
+   return result;
 }
 
 bool ZmqStreamServerConnection::SendDataToAllClients(const std::string& data)
 {
    unsigned int successCount = 0;
 
-   if (transport_) {
-      for (const auto &client : clientInfo_) {
-         if (transport_->sendData(client.first, data)) {
-            successCount++;
-         }
+   FastLock locker(connectionsLockFlag_);
+   for (auto & it : activeConnections_) {
+      const bool result = it.second->send(data);
+      if (result) {
+         successCount++;
       }
-      return (successCount == clientInfo_.size());
    }
-   else {
-      FastLock locker(connectionsLockFlag_);
-      for (const auto &it : activeConnections_) {
-         const bool result = it.second->send(data);
-         if (result) {
-            successCount++;
-         }
-      }
-      return (successCount == activeConnections_.size());
-   }
+   return (successCount == activeConnections_.size());
 }
 
 ZmqStreamServerConnection::server_connection_ptr

--- a/BlocksettleNetworkingLib/ZmqStreamServerConnection.h
+++ b/BlocksettleNetworkingLib/ZmqStreamServerConnection.h
@@ -31,8 +31,7 @@ protected:
 
 public:
    ZmqStreamServerConnection(const std::shared_ptr<spdlog::logger>& logger
-      , const std::shared_ptr<ZmqContext>& context
-      , const std::shared_ptr<bs::network::TransportServer> &tr = nullptr);
+      , const std::shared_ptr<ZmqContext>& context);
    ~ZmqStreamServerConnection() noexcept override = default;
 
    ZmqStreamServerConnection(const ZmqStreamServerConnection&) = delete;
@@ -43,7 +42,6 @@ public:
 
    bool SendDataToClient(const std::string& clientId, const std::string& data) override;
    bool SendDataToAllClients(const std::string& data) override;
-
 protected:
    ZmqContext::sock_ptr CreateDataSocket() override;
 
@@ -63,7 +61,6 @@ private:
    std::atomic_flag                 connectionsLockFlag_ = ATOMIC_FLAG_INIT;
 
    std::unordered_map<std::string, server_connection_ptr> activeConnections_;
-   std::string accumulBuf_;
 };
 
 #endif // __ZMQ_STREAM_SERVER_CONNECTION_H__

--- a/Blocksettle_proto/Communication/bs_md_status.proto
+++ b/Blocksettle_proto/Communication/bs_md_status.proto
@@ -42,25 +42,31 @@ message MDStatusServerStatus
    // FX stream timeouts
    // timeout - time interval since last pair received. in ms
    uint64 eur_gbp_timeout = 4;
-   uint64 eur_sek_timeout = 5;
-   uint64 gbp_sek_timeout = 6;
-   uint64 eur_jpy_timeout = 7;
-   uint64 gbp_jpy_timeout = 8;
-   uint64 jpy_sek_timeout = 9;
-   uint64 eur_usd_timeout = 10;
+   uint64 eur_cad_timeout = 5;
+   uint64 gbp_cad_timeout = 6;
+   uint64 eur_usd_timeout = 7;
+   uint64 gbp_usd_timeout = 8;
+   uint64 usd_cad_timeout = 9;
+   uint64 eur_pln_timeout = 10;
+   uint64 gbp_pln_timeout = 11;
+   uint64 usd_pln_timeout = 12;
+   uint64 cad_pln_timeout = 13;
 
-   bool eur_gbp_from_xbt = 11;
-   bool eur_sek_from_xbt = 12;
-   bool gbp_sek_from_xbt = 13;
-   bool eur_jpy_from_xbt = 14;
-   bool gbp_jpy_from_xbt = 15;
-   bool jpy_sek_from_xbt = 16;
+   bool eur_gbp_from_xbt = 14;
+   bool eur_cad_from_xbt = 15;
+   bool gbp_cad_from_xbt = 16;
    bool eur_usd_from_xbt = 17;
+   bool gbp_usd_from_xbt = 18;
+   bool usd_cad_from_xbt = 19;
+   bool eur_pln_from_xbt = 20;
+   bool gbp_pln_from_xbt = 21;
+   bool usd_pln_from_xbt = 22;
+   bool cad_pln_from_xbt = 23;
 
    // XBT stream timeouts
-   uint64 xbt_gbp_timeout = 18;
-   uint64 xbt_eur_timeout = 19;
-   uint64 xbt_sek_timeout = 20;
-   uint64 xbt_jpy_timeout = 21;
-   uint64 xbt_usd_timeout = 22;
+   uint64 xbt_eur_timeout = 24;
+   uint64 xbt_gbp_timeout = 25;
+   uint64 xbt_pln_timeout = 26;
+   uint64 xbt_cad_timeout = 27;
+   uint64 xbt_usd_timeout = 28;
 }

--- a/Blocksettle_proto/Communication/bs_proxy_pb.proto
+++ b/Blocksettle_proto/Communication/bs_proxy_pb.proto
@@ -55,6 +55,7 @@ message Request
    {
       bytes auth_addresses_signed = 1;
       bytes cc_addresses_signed = 2;
+      bs.types.TradeSettings trade_settings = 3;
    }
 
    message TermRep
@@ -63,13 +64,6 @@ message Request
       bool success = 2;
       string error_msg = 3;
       int64 internal_request_id = 4;
-   }
-
-   message TermRepSubmitAuthAddr
-   {
-      TermRep term_rep = 1;
-      int32 validation_amount_cents = 2;
-      bool confirmation_required = 3;
    }
 
    message UpdateFeeRate
@@ -90,12 +84,18 @@ message Request
       bool     trading_enabled   = 2;
    }
 
+   message CheckApiKey
+   {
+      bytes client_id = 1;
+      string api_key = 2;
+      string email = 3;
+   }
+
    oneof data
    {
       // Messages
       Terminal                terminal                = 30;
       UserInfo                user_info               = 31;
-      TermRepSubmitAuthAddr   submit_auth_address     = 32;
       TermRep                 confirm_auth_address    = 33;
       TermRep                 submit_cc_address       = 34;
       TermRep                 confirm_cc_address      = 35;
@@ -104,6 +104,7 @@ message Request
       UpdateFeeRate           update_fee_rate         = 38;
       UpdateBalance           update_balance          = 39;
       TradingStatus           trading_status_update   = 40;
+      CheckApiKey             check_api_key           = 41;
    }
 }
 
@@ -154,6 +155,13 @@ message Response
       string cc_product = 3;
    }
 
+   message CheckApiKey
+   {
+      bytes client_id = 1;
+      string api_key = 2;
+      string ip_addr = 3;
+   }
+
    oneof data
    {
       // Messages
@@ -161,9 +169,9 @@ message Response
       OnlineUsers online_users = 31;
       ClientConnected client_connected = 32;
       ClientDisconnected client_disconnected = 33;
-      TermReq submit_auth_address = 34;
       TermReq confirm_auth_address = 35;
       TermReqCc submit_cc_address = 36;
       TermReqCc confirm_cc_address = 37;
+      CheckApiKey check_api_key = 38;
    }
 }

--- a/Blocksettle_proto/Communication/bs_proxy_terminal.proto
+++ b/Blocksettle_proto/Communication/bs_proxy_terminal.proto
@@ -34,6 +34,11 @@ message Request
         string email = 1;
     }
 
+    message Authorize
+    {
+        string api_key = 1;
+    }
+
     message Celer
     {
         int32 message_type = 1;
@@ -69,15 +74,15 @@ message Request
     oneof data
     {
         // Requests (there must be some response after some time)
-        StartLogin start_login = 10;
-        Empty get_login_result = 11;
-        GetEmailHash get_email_hash = 14;
-        Address submit_auth_address = 15;
-        Address sign_auth_address = 16;
-        Address confirm_auth_address = 17;
-        SubmitCcAddress submit_cc_address = 18;
-        Address sign_cc_address = 19;
-        Address confirm_cc_address = 20;
+        StartLogin      start_login          = 10;
+        Empty           get_login_result     = 11;
+        GetEmailHash    get_email_hash       = 14;
+        Address         sign_auth_address    = 16;
+        Address         confirm_auth_address = 17;
+        SubmitCcAddress submit_cc_address    = 18;
+        Address         sign_cc_address      = 19;
+        Address         confirm_cc_address   = 20;
+        Authorize       authorize            = 21;
 
         // Messages
         Empty cancel_login = 30;
@@ -93,6 +98,11 @@ message Response
     message StartLogin
     {
         AuthEidError error = 1;
+    }
+
+    message Authorize
+    {
+        string email = 1;
     }
 
     message GetLoginResult
@@ -118,6 +128,8 @@ message Response
         float fee_rate = 9;
 
         string terminal_user_id = 10;
+
+        bs.types.TradeSettings trade_settings = 11;
     }
 
     message Celer
@@ -188,15 +200,15 @@ message Response
     oneof data
     {
         // Responses
-        StartLogin start_login = 10;
-        GetLoginResult get_login_result = 11;
-        GetEmailHash get_email_hash = 14;
-        SubmitAuthAddress submit_auth_address = 15;
-        Sign sign_auth_address = 16;
-        Basic confirm_auth_submit = 17;
-        Basic submit_cc_address = 18;
-        Sign sign_cc_address = 19;
-        Basic confirm_cc_address = 20;
+        StartLogin         start_login          = 10;
+        GetLoginResult     get_login_result     = 11;
+        GetEmailHash       get_email_hash       = 14;
+        Sign               sign_auth_address    = 16;
+        Basic              confirm_auth_submit  = 17;
+        Basic              submit_cc_address    = 18;
+        Sign               sign_cc_address      = 19;
+        Basic              confirm_cc_address   = 20;
+        Authorize          authorize            = 21;
 
         // Messages
         Celer              celer                = 30;

--- a/Blocksettle_proto/Communication/bs_server.proto
+++ b/Blocksettle_proto/Communication/bs_server.proto
@@ -70,7 +70,7 @@ enum ArmoryMessageType
    ArmoryStopSettlement    = 11;
    ArmoryGetSpentness      = 12;
    ArmoryGetTxByHash       = 13;
-   ArmoryValidateAuthAddr  = 14;
+   ArmoryAuthWalletLoaded  = 14;
    ArmoryBroadcastTimeout  = 15;
    ArmoryGetOutpointsForAddrList = 16;
    ArmoryUpdateAuthAddrs   = 17;
@@ -78,6 +78,7 @@ enum ArmoryMessageType
    ArmoryPushXbtTXs        = 19;
    ArmoryGetOutputsForOPs  = 20;
    ArmorySettlementsStatus = 21;
+   ArmoryGetSpendableUTXOs = 22;
 }
 
 enum ArmoryStateData
@@ -210,18 +211,9 @@ message ArmoryGetTxResponse
    string error_text = 2;
 }
 
-message ArmoryValidateAuthRequest
+message ArmoryAuthAddresses
 {
    repeated string addresses = 1;
-}
-
-message ArmoryValidateAuthResponse
-{
-   message ValidateAuthResult {
-      string address = 1;
-      int32  result = 3;
-   }
-   repeated ValidateAuthResult results = 1;
 }
 
 message ArmoryUpdateAuthAddrsRequest
@@ -237,12 +229,19 @@ message ArmoryUpdateCcAddrsRequest
 message ArmoryGetOutpointsForAddrListRequest
 {
    repeated string addresses = 1;
+   uint32 height = 2;
+   uint32 zc_index = 3;
 }
 
 message ArmoryGetOutpointsForAddrListResponse
 {
-   // Add other fields if needed here (isSpent_, value_, heightCutoff_ etc)
-   repeated OutPointData outpoints = 1;
+   message OutPoint {
+      bytes id = 1;
+      repeated OutPointData outpoints = 2;
+   }
+   repeated OutPoint outpoints = 1;
+   uint32 height_cutoff = 2;
+   uint32 zc_index_cutoff = 3;   
 }
 
 message ArmoryGetOutputsForOPsRequest
@@ -256,6 +255,18 @@ message ArmoryGetOutputsForOPsResponse
 {
    repeated bytes utxos = 1;
    string settlement_id = 2;
+}
+
+message ArmoryGetSpendableUTXOsRequest
+{
+   string wallet_id = 1;
+   string address = 2;
+   bool   with_ZC = 3;
+}
+
+message ArmoryGetSpendableUTXOsResponse
+{
+   repeated bytes utxos = 1;
 }
 
 message ArmoryMessage
@@ -276,8 +287,7 @@ message ArmoryMessage
       ArmorySpentnessResponse                spentness_response      = 13;
       ArmoryGetTxRequest                     tx_request              = 14;
       ArmoryGetTxResponse                    tx_response             = 15;
-      ArmoryValidateAuthRequest              auth_request            = 16;
-      ArmoryValidateAuthResponse             auth_response           = 17;
+      ArmoryAuthAddresses                    auth_addresses          = 16;
       ArmoryGetOutpointsForAddrListRequest   out_points_request      = 19;
       ArmoryGetOutpointsForAddrListResponse  out_points_response     = 20;
       ArmoryUpdateAuthAddrsRequest           update_auth_addrs       = 21;
@@ -288,6 +298,8 @@ message ArmoryMessage
       bytes                                  timeout_id              = 26;
       bool                                   get_all_utxo            = 27;
       bool                                   settlements_suspended   = 28;
+      ArmoryGetSpendableUTXOsRequest         spendable_utxos_request = 29;
+      ArmoryGetSpendableUTXOsResponse        spendable_utxos_response= 30;
    }
 }
 
@@ -442,12 +454,11 @@ enum GenoaType
    GenoaSendCCToken              = 24;
    GenoaReserveCC                = 25;
    GenoaCompleteCCReserve        = 26;
-   GenoaAuthFeeMake              = 27;
-   GenoaAuthFeeConfirm           = 28;
    GenoaGetUserAccounts          = 29;
    GenoaGetAccountBalance        = 30;
    GenoaEODUpdate                = 31;
    GenoaMigrateUserIds           = 32;
+   GenoaApiKey                   = 33;
 }
 
 message GenoaConnectedBroadcast
@@ -671,33 +682,6 @@ message GenoaAccountMessage
    }
 }
 
-message GenoaAuthFeeMakeRequest
-{
-   string email      = 1;
-   string auth_address = 2;
-   uint64 xbt_amount = 3;
-}
-
-message GenoaAuthFeeMakeResponse
-{
-   bool success         = 1;
-   string error_msg     = 2;
-   float eur_emount     = 3;
-   uint64 xbt_amount    = 4;
-   string error_code    = 5;
-}
-
-message GenoaAuthFeeConfirmRequest
-{
-   string      auth_address   = 1;
-}
-
-message GenoaAuthFeeUpdateResponse
-{
-   bool success         = 1;
-   string error_msg     = 2;
-}
-
 message GenoaAccountData
 {
    string email = 1;
@@ -745,6 +729,18 @@ message GenoaEODUpdateMessage
    repeated GenoaPrice  prices   = 2;
 }
 
+message GenoaApiKeyCheckRequest
+{
+   string api_key = 1;
+   string ip_addr = 2;
+}
+
+message GenoaApiKeyCheckResponse
+{
+   string api_key = 1;
+   string email = 2;
+}
+
 message GenoaMessage
 {
    GenoaType type = 1;
@@ -771,15 +767,13 @@ message GenoaMessage
       GenoaSendCCTokenRequest          cc_token                   = 21;
       TradeInfoCcData                  cc_reserve                 = 22;
       string                           settlement_id              = 23;
-      GenoaAuthFeeMakeRequest          auth_fee_make_request      = 24;
-      GenoaAuthFeeMakeResponse         auth_fee_make_response     = 25;
-      GenoaAuthFeeConfirmRequest       auth_fee_confirm_request   = 26;
-      GenoaAuthFeeUpdateResponse       auth_fee_confirm_response  = 27;
       string                           user_email                 = 28;
       GenoaAccountInfoResponse         user_account_response      = 29;
       GenoaAccountBalanceRequest       acc_balance_request        = 30;
       GenoaAccountBalanceResponse      acc_balance_response       = 31;
       GenoaEODUpdateMessage            eod_update                 = 32;
+      GenoaApiKeyCheckRequest          api_key_request            = 33;
+      GenoaApiKeyCheckResponse         api_key_response           = 34;
    }
 }
 
@@ -1131,6 +1125,11 @@ message OutPointData
 {
    bytes  hash = 1;
    uint32 index = 2;
+   uint32 tx_height = 3;
+   uint32 tx_index = 4;
+   uint64 value = 5;
+   bool   spent = 6;
+   bytes  spender_hash = 7;
 }
 
 message TradeDataCcMessage
@@ -1468,4 +1467,36 @@ message RelayedMessage
 {
    RelayUser user = 1;
    bytes data = 2;
+}
+
+message AuthManaging
+{
+   message AuthAddressConfirm
+   {
+      string   user     = 1;
+      string   address  = 2;
+   }
+
+   message SettledXbtTradeNotification
+   {
+      string settlement_id       = 1;
+
+      string requester_address   = 2;
+      string dealer_address      = 3;
+   }
+
+   message FilterAuthFundUTXOs
+   {
+      repeated bytes utxos = 1;
+   }
+
+   oneof data
+   {
+      AuthAddressConfirm   auth_confirm_request    = 1;
+      bool                 auth_confirm_response   = 2;
+
+      SettledXbtTradeNotification   settled_xbt_trade  = 3;
+
+      FilterAuthFundUTXOs  auth_fund_utxos = 4;
+   }
 }

--- a/Blocksettle_proto/Communication/bs_server_storage.proto
+++ b/Blocksettle_proto/Communication/bs_server_storage.proto
@@ -67,68 +67,91 @@ enum StorageMessageType
    StorageDataAvail   = 4;
 }
 
-message StorageAuthReservation
+
+message AuthAddress
 {
-   enum AuthReservationState
+   string   auth_address   = 1;
+   string   user_name      = 2;
+}
+
+message AuthAddressInfo
+{
+   string   auth_address   = 1;
+   string   user_name      = 2;
+   int32    address_state  = 3;
+}
+
+message SubmittedAddressQuery
+{
+   string user_name  = 1;
+}
+
+message SubmittedAddressResponse
+{
+   string            user_name   = 1;
+   repeated string   address     = 2;
+}
+
+message LoadActiveAddressRequest
+{
+   // empty
+}
+
+message ActiveAddressListResponse
+{
+   message ActiveAddressInfo
    {
-      AuthReservationUndefined         = 0;
-      AuthReservationPendingApproval   = 1;
-      AuthReservationReserved          = 2;
-      AuthReservationRejected          = 3;
-      AuthReservationConfirmed         = 4;
+      string   user_name         = 1;
+      string   address           = 2;
+      int32    address_state     = 3;
+      int64    settlement_count  = 4;
    }
 
-   string               address     = 1;
-   string               user        = 2;
-   uint64               xbt_amount  = 3;
-   double               eur_amount  = 4;
-   AuthReservationState state       = 5;
+   repeated ActiveAddressInfo active_address = 1;
 }
 
-message StorageAuthAddressState
+message UpdateXbtSettlementCountRequest
 {
-   enum AuthAddressStatus
-   {
-      AuthAddressFunded       = 0;
-      AuthAddressRevoked      = 1;
-      AuthAddressBlacklisted  = 2;
-      AuthAddressUnknown      = 3;
-   }
-
-   string            address  = 1;
-   string            user     = 2;
-   AuthAddressStatus status   = 3;
+   string settlement_id          = 1;
+   string requester_auth_address = 2;
+   string dealer_auth_address    = 3;
 }
 
-message StorageAuthReservationResponse
+message UpdateXbtSettlementCountResponse
 {
-   bool                    result            = 1;
-   string                  error_message     = 2;
-   StorageAuthReservation  reservation_info  = 3;
-}
+   bool  processed         = 1;
+   bool  counters_updated  = 2;
 
-message StorageAuthAddressStateResponse
-{
-   bool     result         = 1;
-   string   error_message  = 2;
+   string   requester_auth_address     = 3;
+   int64    requester_settlement_count = 4;
+
+   string   dealer_auth_address        = 5;
+   int64    dealer_settlement_count    = 6;
 }
 
 message StorageAddressMessage
 {
-   enum StorageAddressDomain
+   oneof data
    {
-      StorageAddressReservationDefinition    = 0;
-      StorageAddressReservationUpdateState   = 1;
-      StorageAddressAuthStatus               = 2;
-   }
+      AuthAddress       submit_auth_address  = 1;
+      AuthAddress       fund_auth_address    = 2;
+      AuthAddress       revoke_auth_address  = 3;
+      string            auth_address         = 4;
 
-   StorageAddressDomain domain = 1;
+      AuthAddressInfo   address_info         = 5;
+      bool              put_result           = 6;
 
-   oneof data {
-      StorageAuthReservation           auth_reservation        = 2;
-      StorageAuthReservationResponse   put_reservation_result  = 3;
-      StorageAuthAddressState          auth_address            = 4;
-      StorageAuthAddressStateResponse  pub_auth_address_result = 5;
+      SubmittedAddressQuery      get_submitted_auth_list    = 7;
+      SubmittedAddressResponse   submitted_address_list     = 8;
+
+      SubmittedAddressQuery      get_submitted_auth_count   = 9;
+      int64                      submitted_address_count    = 10;
+
+      LoadActiveAddressRequest   get_active_address_list    = 11;
+      ActiveAddressListResponse  active_address_list        = 12;
+
+      UpdateXbtSettlementCountRequest  update_settlement_count          = 13;
+      UpdateXbtSettlementCountResponse update_settlement_count_result   = 14;
    }
 }
 
@@ -428,6 +451,9 @@ message UserScoreUpdateEvent
       UnexpectedDealerCCHalf           = 29;
       UnexpectedRequesterCCHalf        = 30;
       UnexpectedCCCancel               = 31;
+
+      // Auth address submit events
+      StolenAuthAddressSubmitted       = 32;
    };
 
    string               user_email     = 1;

--- a/Blocksettle_proto/Communication/bs_signer.proto
+++ b/Blocksettle_proto/Communication/bs_signer.proto
@@ -157,9 +157,16 @@ enum ControlPasswordStatus
 
 ////////////////////////////////////////////////////////////////////////////////
 
-message PeerEvent
+message ClientConnected
 {
-   string ip_address = 1;
+   bytes client_id = 1;
+   string ip_address = 2;
+   string public_key = 3;
+}
+
+message ClientDisconnected
+{
+   bytes client_id = 1;
 }
 
 message SignTxEvent

--- a/Blocksettle_proto/Communication/bs_types.proto
+++ b/Blocksettle_proto/Communication/bs_types.proto
@@ -62,3 +62,11 @@ message Balance
     string currency = 1;
     double balance = 2;
 }
+
+message TradeSettings
+{
+    uint64 xbt_tier1_limit = 1;
+    uint32 xbt_price_band = 2;
+    uint32 auth_required_settled_trades = 3;
+    uint32 auth_submit_address_limit = 4;
+}

--- a/WalletsLib/Address.cpp
+++ b/WalletsLib/Address.cpp
@@ -578,3 +578,8 @@ bs::Address bs::Address::fromMultisigScript(const BinaryData& data, AddressEntry
 
    return bs::Address(hash, aet);
 }
+
+bs::Address bs::Address::fromPrefixed(const BinaryData &prefixed)
+{
+   return bs::Address(prefixed);
+}

--- a/WalletsLib/Address.h
+++ b/WalletsLib/Address.h
@@ -44,9 +44,13 @@ namespace bs {
       Address(const Address&) = default;
 
       bool operator==(const Address &) const;
+      bool operator==(const BinaryData &pfx) const { return prefixed() == pfx; }
       bool operator!=(const Address &addr) const { return !((*this) == addr); }
+      bool operator!=(const BinaryData &prefixed) const { return id() != prefixed; }
       bool operator<(const Address &addr) const { return (id() < addr.id()); }
+      bool operator<(const BinaryData &prefixed) const { return (id() < prefixed); }
       bool operator>(const Address &addr) const { return (id() > addr.id()); }
+      bool operator>(const BinaryData &prefixed) const { return (id() > prefixed); }
 
       AddressEntryType getType() const { return aet_; }
       Format format() const { return format_; }
@@ -73,6 +77,7 @@ namespace bs {
       static bs::Address fromAddressString(const std::string&);
       static bs::Address fromAddressEntry(const AddressEntry&);
       static bs::Address fromMultisigScript(const BinaryData&, AddressEntryType);
+      static bs::Address fromPrefixed(const BinaryData &);
 
       static size_t getPayoutWitnessDataSize();
 

--- a/WalletsLib/AuthAddress.h
+++ b/WalletsLib/AuthAddress.h
@@ -18,24 +18,22 @@
 
 enum class AddressVerificationState
 {
-   // VerificationFailed - there were errors/isses while getting address verification state
+   // VerificationFailed - there were errors/issues while getting address verification state
    VerificationFailed = 0,
-   // InProgress - address verification state is not defined yet
-   InProgress,
-   // NotSubmitted - address do not have verification transaction
-   NotSubmitted,
-   // Submitted - there is unconfirmed transaction from BS
-   Submitted,
-   // PendingVerification - there is confirmed transaction from BS, but nothing returned back
-   PendingVerification,
-   // VerificationSubmitted - there is unconfirmed verification from auth address back to validation address
-   VerificationSubmitted,
+   // Virgin - address does not have history
+   Virgin,
+   // Tainted - address has no validation outputs but has history
+   Tainted,
+   // Submitted - address has a validation output without enough confirmations
+   Verifying,
    // Verified - address is verified
    Verified,
-   // Revoked - address is revoked by customer
+   // Revoked - address is revoked (by user)
    Revoked,
-   // evokedByBS - address is revoked by BS
-   RevokedByBS
+   // Invalidated - address was invalidated by a validation address (explicit) or 
+   // validation address for this user address was revoked (implicit)
+   Invalidated_Explicit,
+   Invalidated_Implicit
 };
 
 std::string to_string(AddressVerificationState state);
@@ -43,7 +41,7 @@ std::string to_string(AddressVerificationState state);
 class AuthAddress
 {
 public:
-   AuthAddress(const bs::Address &chainedAddress, AddressVerificationState state = AddressVerificationState::InProgress);
+   AuthAddress(const bs::Address &chainedAddress, AddressVerificationState state = AddressVerificationState::VerificationFailed);
    ~AuthAddress() noexcept = default;
 
    AuthAddress(const AuthAddress&) = default;

--- a/WalletsLib/XBTAmount.h
+++ b/WalletsLib/XBTAmount.h
@@ -47,24 +47,28 @@ namespace bs {
          return (value_ != UINT64_MAX);
       }
 
-      bool operator==(const XBTAmount &other) const
+      bool operator == (const XBTAmount &other) const
       {
          return (value_ == other.value_);
       }
-      bool operator!=(const XBTAmount &other) const
+      bool operator != (const XBTAmount &other) const
       {
          return (value_ != other.value_);
       }
-      bool operator>(const BTCNumericTypes::satoshi_type other) const
+      bool operator > (const BTCNumericTypes::satoshi_type other) const
       {
          return (value_ > other);
       }
+      bool operator > (const XBTAmount& other) const
+      {
+         return (value_ > other.value_);
+      }
 
-      XBTAmount operator+(const XBTAmount &other) const
+      XBTAmount operator + (const XBTAmount &other) const
       {
          return XBTAmount(value_ + other.value_);
       }
-      int64_t operator-(const XBTAmount &other) const
+      int64_t operator - (const XBTAmount &other) const
       {
          return (int64_t)value_ - (int64_t)other.value_;
       }

--- a/build_scripts/websockets_settings.py
+++ b/build_scripts/websockets_settings.py
@@ -23,7 +23,7 @@ class WebsocketsSettings(Configurator):
         self._version = '4.0.15'
         self._package_name = 'libwebsockets'
         self._package_url = 'https://github.com/warmcat/libwebsockets/archive/v' + self._version + '.zip'
-        self._script_revision = '8'
+        self._script_revision = '9'
 
     def get_package_name(self):
         return self._package_name + '-' + self._version
@@ -93,6 +93,9 @@ class WebsocketsSettings(Configurator):
             env_vars['LDFLAGS'] = "crypt32.Lib"
         if self._project_settings.on_osx():
             env_vars['LDFLAGS'] = "-L" + self.openssl.get_install_dir() + "/lib"
+
+        # Workaround for data race: https://github.com/warmcat/libwebsockets/issues/1836
+        env_vars['CFLAGS'] = "-Dmalloc_usable_size="
 
         result = subprocess.call(command, env=env_vars)
         return result == 0

--- a/build_scripts/websockets_settings.py
+++ b/build_scripts/websockets_settings.py
@@ -95,7 +95,7 @@ class WebsocketsSettings(Configurator):
             env_vars['LDFLAGS'] = "-L" + self.openssl.get_install_dir() + "/lib"
 
         # Workaround for data race: https://github.com/warmcat/libwebsockets/issues/1836
-        env_vars['CFLAGS'] = "-Dmalloc_usable_size="
+        #env_vars['CFLAGS'] = "-Dmalloc_usable_size="
 
         result = subprocess.call(command, env=env_vars)
         return result == 0

--- a/build_scripts/websockets_settings.py
+++ b/build_scripts/websockets_settings.py
@@ -95,7 +95,7 @@ class WebsocketsSettings(Configurator):
             env_vars['LDFLAGS'] = "-L" + self.openssl.get_install_dir() + "/lib"
 
         # Workaround for data race: https://github.com/warmcat/libwebsockets/issues/1836
-        #env_vars['CFLAGS'] = "-Dmalloc_usable_size="
+        env_vars['CFLAGS'] = "-Dmalloc_usable_size=INVALID_DEFINE_TO_DISABLE_FLAG"
 
         result = subprocess.call(command, env=env_vars)
         return result == 0


### PR DESCRIPTION
- Add session resuming to WsDataConnection/WsServerConnection.
  Needed when Cloudflare servers restarted.
  Reimplement something that we had with ZMQ (transparent TCP restarts)
- Add Bip*Connection that could handle BIP encryption for other connections.
  Superfluous TransportBIP15x* could be removed later.
- Fix BIP15X rekeying regression from client side.
- Remove adding Transport to ZMQ streams.