### PR TITLE
Fix CC UTXO refresh

### DIFF
--- a/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
+++ b/BlocksettleNetworkingLib/Wallets/SyncWalletsManager.h
@@ -336,6 +336,7 @@ namespace bs {
          // Cached CC outpoint maps from CC tracker.
          // Used to detect CC balance changes.
          std::map<std::string, std::map<BinaryData, std::set<unsigned>>> ccOutpointMapsFromTracker_;
+         std::map<std::string, std::map<BinaryData, std::set<unsigned>>> ccOutpointMapsFromTrackerZc_;
          std::mutex ccOutpointMapsFromTrackerMutex_;
 
          ValidityFlag   validityFlag_;


### PR DESCRIPTION
When new block is mined `ccLeaf->getOutpointMapFromTracker(true)` is not updated as ZC outpoints are simply moved from ZC to confirmed state. As the result `walletBalanceUpdated` was not called.