### PR TITLE
Detect failed AEAD

### DIFF
--- a/BlocksettleNetworkingLib/DataConnection.h
+++ b/BlocksettleNetworkingLib/DataConnection.h
@@ -11,6 +11,8 @@
 #ifndef __DATA_CONNECTION_H__
 #define __DATA_CONNECTION_H__
 
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -42,6 +44,10 @@ public:
    virtual bool closeConnection() = 0;
 
    virtual bool isActive() const = 0;
+
+   // Execute callback after timeout on listening thread
+   using TimerCallback = std::function<void()>;
+   virtual bool timer(std::chrono::milliseconds /*timeout*/, TimerCallback /*callback*/) { return false; }
 
 protected:
    void setListener(DataConnectionListener* listener) {

--- a/BlocksettleNetworkingLib/ServerConnection.h
+++ b/BlocksettleNetworkingLib/ServerConnection.h
@@ -13,6 +13,7 @@
 
 #include "ServerConnectionListener.h"
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -34,6 +35,13 @@ public:
 
    virtual bool SendDataToClient(const std::string& clientId, const std::string& data) = 0;
    virtual bool SendDataToAllClients(const std::string&) { return false; }
+
+   // Execute callback after timeout on listening thread
+   using TimerCallback = std::function<void()>;
+   virtual bool timer(std::chrono::milliseconds /*timeout*/, TimerCallback /*callback*/) { return false; }
+
+   // Close client connection
+   virtual bool closeClient(const std::string& /*clientId*/) { return false; }
 };
 
 #endif // __SERVER_CONNECTION_H__

--- a/BlocksettleNetworkingLib/Transport.h
+++ b/BlocksettleNetworkingLib/Transport.h
@@ -77,6 +77,8 @@ namespace bs {
          using DisconnectedCb = std::function<void(const std::string &clientId)>;
          void setDisconnectedCb(const DisconnectedCb &disconnCb) { disconnCb_ = disconnCb; }
 
+         virtual bool handshakeComplete(const std::string &clientId) = 0;
+
       protected:
          ClientErrorCb        clientErrorCb_{ nullptr };
          DataReceivedCb       dataReceivedCb_{ nullptr };

--- a/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
+++ b/BlocksettleNetworkingLib/TransportBIP15xServer.cpp
@@ -467,6 +467,15 @@ void TransportBIP15xServer::reportFatalError(const std::shared_ptr<BIP15xPerConn
    }
 }
 
+bool TransportBIP15xServer::handshakeComplete(const std::string &clientId)
+{
+   auto connection = GetConnection(clientId);
+   if (!connection) {
+      return false;
+   }
+   return (connection->encData_->getBIP150State() == BIP150State::SUCCESS);
+}
+
 BIP15xServerParams TransportBIP15xServer::getParams(unsigned port) const
 {
    auto addPeersLbd = [this](const BIP15xPeer& peer)

--- a/BlocksettleNetworkingLib/TransportBIP15xServer.h
+++ b/BlocksettleNetworkingLib/TransportBIP15xServer.h
@@ -112,6 +112,7 @@ namespace bs {
          // Returns null if clientId is not known or was not yet authenticated.
          std::unique_ptr<BIP15xPeer> getClientKey(const std::string &clientId) const;
 
+         bool handshakeComplete(const std::string &clientId) override;
          BIP15xServerParams getParams(unsigned) const;
 
       private:

--- a/BlocksettleNetworkingLib/WsCommonPrivate.cpp
+++ b/BlocksettleNetworkingLib/WsCommonPrivate.cpp
@@ -1,0 +1,67 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#include "WsCommonPrivate.h"
+
+#include <cassert>
+#include <cstring>
+
+#include <libwebsockets.h>
+
+using namespace bs::network::ws;
+
+struct WsTimerHelperDataInt : lws_sorted_usec_list_t
+{
+   WsTimerHelperData *owner;
+};
+
+class bs::network::ws::WsTimerHelperData
+{
+public:
+   WsTimerHelper *owner_{};
+   WsTimerHelperDataInt timerInt_;
+   uint64_t timerId_{};
+   WsTimerHelper::TimerCallback callback_;
+};
+
+WsTimerHelper::WsTimerHelper() = default;
+WsTimerHelper::~WsTimerHelper() = default;
+
+void WsTimerHelper::scheduleCallback(lws_context *context, std::chrono::milliseconds timeout, WsTimerHelper::TimerCallback callback)
+{
+   auto timerId = nextTimerId_;
+   nextTimerId_ += 1;
+
+   auto timer = std::make_unique<bs::network::ws::WsTimerHelperData>();
+   std::memset(&timer->timerInt_, 0, sizeof(timer->timerInt_));
+   timer->timerInt_.owner = timer.get();
+   timer->owner_ = this;
+   timer->timerId_ = timerId;
+   timer->callback_ = std::move(callback);
+
+   lws_sul_schedule(context, 0, &timer->timerInt_, timerCallback, static_cast<lws_usec_t>(timeout / std::chrono::microseconds(1)));
+
+   timers_.insert(std::make_pair(timerId, std::move(timer)));
+}
+
+void WsTimerHelper::clear()
+{
+   timers_.clear();
+   nextTimerId_ = {};
+}
+
+void WsTimerHelper::timerCallback(lws_sorted_usec_list *list)
+{
+   auto dataInt = static_cast<WsTimerHelperDataInt*>(list);
+   auto data = dataInt->owner;
+   data->callback_();
+   auto count = data->owner_->timers_.erase(data->timerId_);
+   assert(count == 1);
+}

--- a/BlocksettleNetworkingLib/WsCommonPrivate.h
+++ b/BlocksettleNetworkingLib/WsCommonPrivate.h
@@ -1,0 +1,51 @@
+/*
+
+***********************************************************************************
+* Copyright (C) 2020 - 2020, BlockSettle AB
+* Distributed under the GNU Affero General Public License (AGPL v3)
+* See LICENSE or http://www.gnu.org/licenses/agpl.html
+*
+**********************************************************************************
+
+*/
+#ifndef WS_COMMON_PRIVATE_H
+#define WS_COMMON_PRIVATE_H
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+
+struct lws_context;
+struct lws_sorted_usec_list;
+
+namespace bs {
+   namespace network {
+      namespace ws {
+
+         class WsTimerHelperData;
+
+         class WsTimerHelper
+         {
+         public:
+            WsTimerHelper();
+            ~WsTimerHelper();
+
+            using TimerCallback = std::function<void()>;
+
+            void scheduleCallback(lws_context *context, std::chrono::milliseconds timeout, TimerCallback callback);
+
+            void clear();
+
+         private:
+            static void timerCallback(lws_sorted_usec_list *list);
+
+            std::map<uint64_t, std::unique_ptr<WsTimerHelperData>> timers_;
+            uint64_t nextTimerId_{};
+         };
+
+      };
+   }
+}
+
+#endif // WS_COMMON_PRIVATE_H

--- a/BlocksettleNetworkingLib/WsDataConnection.cpp
+++ b/BlocksettleNetworkingLib/WsDataConnection.cpp
@@ -147,6 +147,20 @@ bool WsDataConnection::isActive() const
    return context_ != nullptr;
 }
 
+bool WsDataConnection::timer(std::chrono::milliseconds timeout, DataConnection::TimerCallback callback)
+{
+   if (!isActive()) {
+      SPDLOG_LOGGER_ERROR(logger_, "can't start timer because connection is not active");
+      return false;
+   }
+   if (listenThread_.get_id() != std::this_thread::get_id()) {
+      SPDLOG_LOGGER_ERROR(logger_, "starting timer from non-listening thread is not supported");
+      return false;
+   }
+   timers_.scheduleCallback(context_, timeout, std::move(callback));
+   return true;
+}
+
 int WsDataConnection::callbackHelper(lws *wsi, int reason, void *user, void *in, size_t len)
 {
    auto context = lws_get_context(wsi);

--- a/BlocksettleNetworkingLib/WsDataConnection.cpp
+++ b/BlocksettleNetworkingLib/WsDataConnection.cpp
@@ -10,8 +10,6 @@
 */
 #include "WsDataConnection.h"
 
-#include "WsConnection.h"
-
 #include <libwebsockets.h>
 #include <openssl/ssl.h>
 #include <openssl/pem.h>

--- a/BlocksettleNetworkingLib/WsDataConnection.h
+++ b/BlocksettleNetworkingLib/WsDataConnection.h
@@ -12,6 +12,7 @@
 #define WS_DATA_CONNECTION_H
 
 #include "DataConnection.h"
+#include "WsCommonPrivate.h"
 #include "WsConnection.h"
 
 #include <atomic>
@@ -56,6 +57,8 @@ public:
 
    bool send(const std::string& data) override;
    bool isActive() const override;
+
+   bool timer(std::chrono::milliseconds timeout, TimerCallback callback) override;
 
    static int callbackHelper(struct lws *wsi, int reason, void *user, void *in, size_t len);
 
@@ -116,6 +119,7 @@ private:
    uint16_t retryCounter_{};
    bool shuttingDownReceived_{};
    std::unique_ptr<lws_retry_bo> retryTable_;
+   bs::network::ws::WsTimerHelper timers_;
 
 };
 

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -48,6 +48,8 @@ struct WsServerConnectionParams
    using FilterCallback = std::function<bool(const std::string &ip)>;
    FilterCallback filterCallback;
 
+   std::chrono::milliseconds handshakeTimeout{std::chrono::seconds(5)};
+
    std::chrono::milliseconds clientTimeout{std::chrono::seconds(30)};
 };
 
@@ -68,9 +70,11 @@ public:
    bool SendDataToClient(const std::string& clientId, const std::string& data) override;
    bool SendDataToAllClients(const std::string&) override;
 
-   static int callbackHelper(struct lws *wsi, int reason, void *in, size_t len);
+   bool timer(std::chrono::milliseconds timeout, TimerCallback callback) override;
 
-   using TimerCallback = std::function<void()>;
+   bool closeClient(const std::string& clientId) override;
+
+   static int callbackHelper(struct lws *wsi, int reason, void *in, size_t len);
 
 private:
    enum class State
@@ -112,6 +116,7 @@ private:
    void listenFunction();
 
    void stopServer();
+   bool isActive() { return listenThread_.joinable(); }
 
    int callback(lws *wsi, int reason, void *in, size_t len);
 
@@ -137,6 +142,7 @@ private:
 
    mutable std::mutex mutex_;
    std::queue<DataToSend> packets_;
+   std::queue<std::string> forceClosingClients_;
 
    // Fields accessible from listener thread only
    std::map<lws*, ConnectionData> connections_;

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -25,7 +25,7 @@ namespace spdlog {
    class logger;
 }
 
-struct WsServerTimer;
+class WsServerTimer;
 struct lws;
 struct lws_context;
 struct lws_sorted_usec_list;

--- a/BlocksettleNetworkingLib/WsServerConnection.h
+++ b/BlocksettleNetworkingLib/WsServerConnection.h
@@ -12,6 +12,7 @@
 #define WS_SERVER_CONNECTION_H
 
 #include "ServerConnection.h"
+#include "WsCommonPrivate.h"
 #include "WsConnection.h"
 
 #include <atomic>
@@ -25,7 +26,6 @@ namespace spdlog {
    class logger;
 }
 
-class WsServerTimer;
 struct lws;
 struct lws_context;
 struct lws_sorted_usec_list;
@@ -120,15 +120,12 @@ private:
 
    int callback(lws *wsi, int reason, void *in, size_t len);
 
-   static void timerCallback(lws_sorted_usec_list *list);
-
    // Methods accessible from listener thread only
    std::string nextClientId();
    bool done() const;
    bool writeNeeded(const ClientData &client) const;
    void requestWriteIfNeeded(const ClientData &client);
    bool processSentAck(ClientData &client, uint64_t sentAckCounter);
-   void scheduleCallback(std::chrono::milliseconds timeout, TimerCallback callback);
    void processError(lws *wsi);
    void closeConnectedClient(const std::string &clientId);
 
@@ -149,9 +146,8 @@ private:
    std::map<std::string, ClientData> clients_;
    std::map<std::string, std::string> cookieToClientIdMap_;
    uint64_t nextClientId_{};
-   std::map<uint64_t, std::unique_ptr<WsServerTimer>> timers_;
-   uint64_t nextTimerId_{};
    bool shuttingDownReceived_{};
+   bs::network::ws::WsTimerHelper timers_;
 
 };
 


### PR DESCRIPTION
BST-2793:
>  BIP15x WS listerners should drop a user connection if it fails to succesfully handshake for AEAD within 5sec of connecting.

Done.

BST-2791:
>  Atm, when the AEAD fails on either side, the connection isn't dropped. Only the handshake sequence halts. This leads to the other side hanging. The connection should be dropped from the side that rejects the handshake.

That's done on server side as result of implementing BST-2793 (failed AEAD client will be disconnected after 5 seconds timeout).
For clients we don't have ability for forcing disconnect. So here same 5 seconds timeout added. After that `Bip15xDataConnection` user (for example `HeadlessContainer`) will detect error and close web socket connection. So the result should be about the same.