### PR TITLE
Few fixes to ManualResetEvent

### DIFF
--- a/CommonLib/ManualResetEvent.cpp
+++ b/CommonLib/ManualResetEvent.cpp
@@ -30,12 +30,10 @@ bool ManualResetEvent::WaitForEvent(const std::chrono::milliseconds& period)
 bool ManualResetEvent::WaitForEvent()
 {  // same applies here (on Linux) - need to build with -pthread which is not the case apparently
    std::unique_lock<std::mutex>  locker(flagMutex_);
-   if (eventFlag_) {
-      return true;
+   while (!eventFlag_) {
+      event_.wait(locker);
    }
-   event_.wait(locker);
-//      [this] () { return eventFlag_.load(); }
-//      );
+
    return eventFlag_;
 }
 
@@ -52,5 +50,4 @@ void ManualResetEvent::ResetEvent()
 {
    std::unique_lock<std::mutex>  locker(flagMutex_);
    eventFlag_ = false;
-   event_.notify_all();
 }

--- a/CommonLib/ManualResetEvent.h
+++ b/CommonLib/ManualResetEvent.h
@@ -36,7 +36,7 @@ public:
 private:
    std::condition_variable event_;
    mutable std::mutex      flagMutex_;
-   std::atomic<bool>       eventFlag_;
+   bool                    eventFlag_;
 };
 
 #endif // __MANUAL_RESET_EVENT_H__


### PR DESCRIPTION
- no need to use atomic, if we use mutex
- each notify_all return control from cv.wait(). Update implementation to avoid return from WaitFor until event actually set